### PR TITLE
fix: add support for Boost >= 1.76

### DIFF
--- a/autoware_utils/CMakeLists.txt
+++ b/autoware_utils/CMakeLists.txt
@@ -5,8 +5,6 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 find_package(Boost REQUIRED)
-target_compile_definitions(autoware_utils
-  PRIVATE BOOST_MAJOR_VERSION=${Boost_MAJOR_VERSION} BOOST_MINOR_VERSION=${Boost_MINOR_VERSION})
 
 file(GLOB_RECURSE src_files
     src/*.cpp
@@ -19,6 +17,8 @@ file(GLOB_RECURSE src_files
 ament_auto_add_library(autoware_utils SHARED
   ${src_files}
 )
+target_compile_definitions(autoware_utils
+  PRIVATE BOOST_MAJOR_VERSION=${Boost_MAJOR_VERSION} BOOST_MINOR_VERSION=${Boost_MINOR_VERSION})
 
 if(BUILD_TESTING)
   file(GLOB_RECURSE test_files test/**/*.cpp)

--- a/autoware_utils/CMakeLists.txt
+++ b/autoware_utils/CMakeLists.txt
@@ -4,6 +4,10 @@ project(autoware_utils)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+find_package(Boost REQUIRED)
+target_compile_definitions(autoware_utils
+  PRIVATE BOOST_MAJOR_VERSION=${Boost_MAJOR_VERSION} BOOST_MINOR_VERSION=${Boost_MINOR_VERSION})
+
 file(GLOB_RECURSE src_files
     src/*.cpp
     src/geometry/*.cpp

--- a/autoware_utils/src/geometry/random_concave_polygon.cpp
+++ b/autoware_utils/src/geometry/random_concave_polygon.cpp
@@ -20,7 +20,12 @@
 #include <boost/geometry/algorithms/correct.hpp>
 #include <boost/geometry/algorithms/intersects.hpp>
 #include <boost/geometry/algorithms/is_valid.hpp>
+
+#if BOOST_MAJOR_VERSION == 1 && BOOST_MINOR_VERSION < 76
 #include <boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>
+#else
+#error TODO: add support for Boost 1.76 or later (Ubuntu 24.04, ROS Jazzy)
+#endif
 
 #include <algorithm>
 #include <limits>


### PR DESCRIPTION
## Description

Boost.Geometry removed the `convex_hull::graham_andrew` strategy (see https://www.boost.org/doc/libs/1_87_0/libs/geometry/doc/html/geometry/release_notes.html#geometry.release_notes.boost_1_76)

This PR has an alternate code path to support both Boost.Geometry < 1.76 (for Ubuntu 22.04, ROS Humble and Iron) and Boost.Geometry >= 1.76 (for Ubuntu 24.04, ROS Jazzy)

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
