### PR TITLE
feat(autoware_utils): porting from universe to core

### DIFF
--- a/autoware_utils/src/geometry/geometry.cpp
+++ b/autoware_utils/src/geometry/geometry.cpp
@@ -301,7 +301,7 @@ Eigen::Vector3d inverse_transform_point(
 }
 
 // Transform point in world coordinates to local coordinates
-geometry_msgs::msg::Point inverseTransformPoint(
+geometry_msgs::msg::Point inverse_transform_point(
   const geometry_msgs::msg::Point & point, const geometry_msgs::msg::Pose & pose)
 {
   const Eigen::Vector3d local_vec =


### PR DESCRIPTION
## Description
replace autoware_universe_utils dependency with autoware_utils for all the packages under universe/planning folder, autoware_utils，what i done: 
1.fix one function nameing pattern issue "from inverseTransformPoint to inverse_transform_point"

**Parent Issue**: -- https://github.com/autowarefoundation/autoware.core/issues/192

## How was this PR tested?
1. test with "colcon build ... ..." for all the packages in autoware folder
2. test with planning simulator with task A-2-B
![Screenshot from 2025-02-24 10-28-02](https://github.com/user-attachments/assets/41871296-9884-4a85-b405-f42560834e2c)


## Notes for reviewers
this pr should be merged with [pr-10191](https://github.com/autowarefoundation/autoware.universe/pull/10191) under universe repo
None.

## Effects on system behavior

None.
