### PR TITLE
feat(autoware_utils_tf): rename package

### DIFF
--- a/autoware_utils/include/autoware_utils/ros/transform_listener.hpp
+++ b/autoware_utils/include/autoware_utils/ros/transform_listener.hpp
@@ -15,13 +15,14 @@
 #ifndef AUTOWARE_UTILS__ROS__TRANSFORM_LISTENER_HPP_
 #define AUTOWARE_UTILS__ROS__TRANSFORM_LISTENER_HPP_
 
-#include <autoware_utils_geometry/transform_listener.hpp>
+// NOLINTBEGIN(build/namespaces, whitespace/line_length)
+// clang-format off
 
-namespace autoware_utils
-{
+#pragma message("#include <autoware_utils/ros/transform_listener.hpp> is deprecated. Use #include <autoware_utils_tf/transform_listener.hpp> instead.")
+#include <autoware_utils_tf/transform_listener.hpp>
+namespace autoware_utils { using namespace autoware_utils_tf; }
 
-using namespace autoware_utils_geometry;  // NOLINT(build/namespaces)
-
-}  // namespace autoware_utils
+// clang-format on
+// NOLINTEND
 
 #endif  // AUTOWARE_UTILS__ROS__TRANSFORM_LISTENER_HPP_

--- a/autoware_utils/package.xml
+++ b/autoware_utils/package.xml
@@ -19,12 +19,12 @@
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
-  <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_logging</depend>
   <depend>autoware_utils_math</depend>
   <depend>autoware_utils_pcl</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_utils_system</depend>
+  <depend>autoware_utils_tf</depend>
   <depend>autoware_utils_uuid</depend>
   <depend>autoware_utils_visualization</depend>
   <depend>autoware_vehicle_msgs</depend>

--- a/autoware_utils_pcl/include/autoware_utils_pcl/managed_transform_buffer.hpp
+++ b/autoware_utils_pcl/include/autoware_utils_pcl/managed_transform_buffer.hpp
@@ -15,7 +15,7 @@
 #ifndef AUTOWARE_UTILS_PCL__MANAGED_TRANSFORM_BUFFER_HPP_
 #define AUTOWARE_UTILS_PCL__MANAGED_TRANSFORM_BUFFER_HPP_
 
-#include <autoware_utils_geometry/transform_listener.hpp>
+#include <autoware_utils_tf/transform_listener.hpp>
 #include <eigen3/Eigen/Core>
 #include <pcl_ros/transforms.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -73,7 +73,7 @@ public:
         return get_static_transform(target_frame, source_frame, eigen_transform);
       };
     } else {
-      tf_listener_ = std::make_unique<autoware_utils_geometry::TransformListener>(node);
+      tf_listener_ = std::make_unique<autoware_utils_tf::TransformListener>(node);
       get_transform_ = [this](
                          const std::string & target_frame, const std::string & source_frame,
                          Eigen::Matrix4f & eigen_transform) {
@@ -173,7 +173,7 @@ private:
     }
 
     // Get the transform from the TF tree
-    tf_listener_ = std::make_unique<autoware_utils_geometry::TransformListener>(node_);
+    tf_listener_ = std::make_unique<autoware_utils_tf::TransformListener>(node_);
     auto tf = tf_listener_->get_transform(
       target_frame, source_frame, rclcpp::Time(0), rclcpp::Duration(1000ms));
     tf_listener_.reset();
@@ -218,7 +218,7 @@ private:
 
   TFMap buffer_;
   rclcpp::Node * const node_;
-  std::unique_ptr<autoware_utils_geometry::TransformListener> tf_listener_;
+  std::unique_ptr<autoware_utils_tf::TransformListener> tf_listener_;
   std::function<bool(const std::string &, const std::string &, Eigen::Matrix4f &)> get_transform_;
 };
 

--- a/autoware_utils_pcl/package.xml
+++ b/autoware_utils_pcl/package.xml
@@ -14,7 +14,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_utils_geometry</depend>
+  <depend>autoware_utils_tf</depend>
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>
 

--- a/autoware_utils_tf/CMakeLists.txt
+++ b/autoware_utils_tf/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(autoware_utils_geometry)
+project(autoware_utils_tf)
 
 find_package(autoware_cmake REQUIRED)
 autoware_package()

--- a/autoware_utils_tf/README.md
+++ b/autoware_utils_tf/README.md
@@ -1,10 +1,10 @@
-# autoware_utils_geometry
+# autoware_utils_tf
 
 ## Overview
 
 The **autoware_utils** library is a comprehensive toolkit designed to facilitate the development of autonomous driving applications.
-This package provides essential utilities for geometry.
-It is extensively used in the Autoware project to handle common tasks such as geometric calculations and message conversions.
+This package provides essential utilities for transform.
+It is extensively used in the Autoware project to handle common tasks such as managing transform listener and vehicle transform.
 
 ## Design
 

--- a/autoware_utils_tf/include/autoware_utils_tf/transform_listener.hpp
+++ b/autoware_utils_tf/include/autoware_utils_tf/transform_listener.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE_UTILS_GEOMETRY__TRANSFORM_LISTENER_HPP_
-#define AUTOWARE_UTILS_GEOMETRY__TRANSFORM_LISTENER_HPP_
+#ifndef AUTOWARE_UTILS_TF__TRANSFORM_LISTENER_HPP_
+#define AUTOWARE_UTILS_TF__TRANSFORM_LISTENER_HPP_
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -26,7 +26,7 @@
 #include <memory>
 #include <string>
 
-namespace autoware_utils_geometry
+namespace autoware_utils_tf
 {
 class TransformListener
 {
@@ -82,6 +82,6 @@ private:
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 };
-}  // namespace autoware_utils_geometry
+}  // namespace autoware_utils_tf
 
-#endif  // AUTOWARE_UTILS_GEOMETRY__TRANSFORM_LISTENER_HPP_
+#endif  // AUTOWARE_UTILS_TF__TRANSFORM_LISTENER_HPP_

--- a/autoware_utils_tf/package.xml
+++ b/autoware_utils_tf/package.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>autoware_utils_geometry</name>
+  <name>autoware_utils_tf</name>
   <version>1.1.0</version>
-  <description>The autoware_utils_geometry package</description>
+  <description>The autoware_utils_tf package</description>
   <maintainer email="egon.kang@autocore.ai">Jian Kang</maintainer>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="esteve.fernandez@tier4.jp">Esteve Fernandez</maintainer>


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware_utils/issues/34
Rename `autoware_utils_geometry` to `autoware_utils_tf`.  The `autoware_utils_geometry` package will be created later for pure geometric logic

## How was this PR tested?

Check that the build of autoware core and universe passes.
## Notes for reviewers

None.

## Effects on system behavior

None.
