### PR TITLE
fix(autoware_utils_geometry): remove reference to hull_graham_andrew to build on Ubuntu Noble

### DIFF
--- a/autoware_utils_geometry/src/geometry/random_concave_polygon.cpp
+++ b/autoware_utils_geometry/src/geometry/random_concave_polygon.cpp
@@ -20,7 +20,6 @@
 #include <boost/geometry/algorithms/correct.hpp>
 #include <boost/geometry/algorithms/intersects.hpp>
 #include <boost/geometry/algorithms/is_valid.hpp>
-#include <boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>
 
 #include <algorithm>
 #include <limits>
@@ -256,8 +255,7 @@ Polygon2d inward_denting(LinearRing2d & ring)
 {
   LinearRing2d convex_ring;
   std::list<Point2d> q;
-  boost::geometry::strategy::convex_hull::graham_andrew<LinearRing2d, Point2d> strategy;
-  boost::geometry::convex_hull(ring, convex_ring, strategy);
+  boost::geometry::convex_hull(ring, convex_ring);
   PolygonWithEdges polygon_with_edges;
   polygon_with_edges.polygon.outer() = convex_ring;
   polygon_with_edges.edges.resize(polygon_with_edges.polygon.outer().size());


### PR DESCRIPTION
## Description

Call the non-strategy version of `boost::geometry::convex_hull()` for compatibility with newer versions of boost, specifically the one on Ubuntu Noble.

## How was this PR tested?

I built it on Ubuntu Noble with https://github.com/ament/ament_cmake/pull/571

## Notes for reviewers

The `graham_andrew` strategy was explicitly removed from Boost's API (https://github.com/boostorg/geometry/commit/1c9e1933b41f27d14f00c2bb06ec81c057fa0150). It looks like the code is still [used it internally](https://www.boost.org/doc/libs/1_87_0/boost/geometry/algorithms/detail/convex_hull/interface.hpp) from the `detail` namespace, but it's no longer a public API. 

## Effects on system behavior

I wouldn't expect any, but I'm out of my expertise here.

Could probably apply the same fix to https://github.com/autowarefoundation/autoware_universe/issues/8982
