### PR TITLE
fix: boost convex_hull for newer boost versions

### DIFF
--- a/autoware_utils_geometry/src/geometry/random_concave_polygon.cpp
+++ b/autoware_utils_geometry/src/geometry/random_concave_polygon.cpp
@@ -28,7 +28,7 @@
 #include <utility>
 #include <vector>
 
-#if __has_include(<boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>)
+#if __has_include(<boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>)  // Until Humble
 #include <boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>
 #endif
 
@@ -259,10 +259,10 @@ Polygon2d inward_denting(LinearRing2d & ring)
 {
   LinearRing2d convex_ring;
   std::list<Point2d> q;
-#if __has_include(<boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>)
+#if __has_include(<boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>)  // Humble
   boost::geometry::strategy::convex_hull::graham_andrew<LinearRing2d, Point2d> strategy;
   boost::geometry::convex_hull(ring, convex_ring, strategy);
-#else
+#else  // Jazzy+
   boost::geometry::convex_hull(ring, convex_ring);
 #endif
   PolygonWithEdges polygon_with_edges;

--- a/autoware_utils_geometry/src/geometry/random_concave_polygon.cpp
+++ b/autoware_utils_geometry/src/geometry/random_concave_polygon.cpp
@@ -20,7 +20,6 @@
 #include <boost/geometry/algorithms/correct.hpp>
 #include <boost/geometry/algorithms/intersects.hpp>
 #include <boost/geometry/algorithms/is_valid.hpp>
-#include <boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>
 
 #include <algorithm>
 #include <limits>
@@ -28,6 +27,10 @@
 #include <random>
 #include <utility>
 #include <vector>
+
+#if __has_include(<boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>)
+#include <boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>
+#endif
 
 namespace autoware_utils_geometry
 {
@@ -256,8 +259,12 @@ Polygon2d inward_denting(LinearRing2d & ring)
 {
   LinearRing2d convex_ring;
   std::list<Point2d> q;
+#if __has_include(<boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>)
   boost::geometry::strategy::convex_hull::graham_andrew<LinearRing2d, Point2d> strategy;
   boost::geometry::convex_hull(ring, convex_ring, strategy);
+#else
+  boost::geometry::convex_hull(ring, convex_ring);
+#endif
   PolygonWithEdges polygon_with_edges;
   polygon_with_edges.polygon.outer() = convex_ring;
   polygon_with_edges.edges.resize(polygon_with_edges.polygon.outer().size());

--- a/autoware_utils_geometry/src/geometry/random_concave_polygon.cpp
+++ b/autoware_utils_geometry/src/geometry/random_concave_polygon.cpp
@@ -20,6 +20,7 @@
 #include <boost/geometry/algorithms/correct.hpp>
 #include <boost/geometry/algorithms/intersects.hpp>
 #include <boost/geometry/algorithms/is_valid.hpp>
+#include <boost/version.hpp>
 
 #include <algorithm>
 #include <limits>
@@ -27,8 +28,7 @@
 #include <random>
 #include <utility>
 #include <vector>
-
-#if __has_include(<boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>)  // Until Humble
+#if BOOST_VERSION < 107600  // Header removed in version 1.76.0 (Humble)
 #include <boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>
 #endif
 
@@ -259,7 +259,7 @@ Polygon2d inward_denting(LinearRing2d & ring)
 {
   LinearRing2d convex_ring;
   std::list<Point2d> q;
-#if __has_include(<boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>)  // Humble
+#if BOOST_VERSION < 107600  // Humble
   boost::geometry::strategy::convex_hull::graham_andrew<LinearRing2d, Point2d> strategy;
   boost::geometry::convex_hull(ring, convex_ring, strategy);
 #else  // Jazzy+


### PR DESCRIPTION
## Description

Several attemps have been made to make autoware compile under ROS Jazzy.

https://github.com/orgs/autowarefoundation/discussions/4893
https://github.com/autowarefoundation/autoware_universe/issues/8982
And the last attempt:
https://github.com/autowarefoundation/autoware_utils/pull/55

It was even removed from the buildfarm because of this reason:
https://github.com/ros/rosdistro/pull/44286

So I made an approach very similar to: https://github.com/autowarefoundation/autoware_universe/pull/7603/files

## How was this PR tested?

It compiles under Jazzy. And has been working (for us) for a few months now.

## Notes for reviewers

If #55 is good to go, that would be the preferred way. If there is too much doubt about it, this might be the more conservative approach.

## Effects on system behavior

None.
