### PR TITLE
fix: include tf2/convert.hpp instead of tf2/convert.h

### DIFF
--- a/autoware_utils_geometry/src/geometry/geometry.cpp
+++ b/autoware_utils_geometry/src/geometry/geometry.cpp
@@ -17,10 +17,9 @@
 #include "autoware_utils_geometry/gjk_2d.hpp"
 
 #include <Eigen/Geometry>
+#include <tf2/convert.hpp>
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
-#include <tf2/convert.h>
 
 #include <string>
 


### PR DESCRIPTION
## Description

Fix https://build.ros2.org/job/Rbin_uN64__autoware_utils_geometry__ubuntu_noble_amd64__binary/14/display/redirect

## How was this PR tested?

Check that the universe build passes.

## Notes for reviewers

None.

## Effects on system behavior

None.
