### PR TITLE
chore: replace INSTANTIATE_TEST_CASE_P with INSTANTIATE_TEST_SUITE_P

### DIFF
--- a/autoware_utils_system/test/cases/lru_cache.cpp
+++ b/autoware_utils_system/test/cases/lru_cache.cpp
@@ -42,7 +42,7 @@ TEST_P(TestLruCache, Main)
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   TestLruCache, TestLruCache,
   testing::Values(
     ParamLruCache{3, {1, 2, 3, 4, 5, 6}, {4, 5, 6}},


### PR DESCRIPTION
## Description
replace INSTANTIATE_TEST_CASE_P with INSTANTIATE_TEST_SUITE_P which will be deprecated.

## How was this PR tested?
pixi init -c conda-forge -c robostack-jazzy autoware_test
cd autoware_test
git clone https://github.com/autowarefoundation/autoware_utils.git
pixi add ros-jazzy-desktop
pixi add ros-jazzy-autoware-cmake
pixi run colcon build --packages-up-to autoware_utils_system

## Notes for reviewers

None.

## Effects on system behavior

None.
