### PR TITLE
fix: add missing fmt dependency

### DIFF
--- a/autoware_utils_debug/CMakeLists.txt
+++ b/autoware_utils_debug/CMakeLists.txt
@@ -8,6 +8,10 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   "src/time_keeper.cpp"
 )
 
+target_link_libraries(${PROJECT_NAME}
+  fmt::fmt
+)
+
 if(BUILD_TESTING)
   file(GLOB_RECURSE test_files test/*.cpp)
   ament_add_ros_isolated_gtest(test_${PROJECT_NAME} ${test_files})

--- a/autoware_utils_debug/package.xml
+++ b/autoware_utils_debug/package.xml
@@ -18,6 +18,7 @@
   <depend>autoware_internal_msgs</depend>
   <depend>autoware_utils_system</depend>
   <depend>diagnostic_msgs</depend>
+  <depend>fmt</depend>
   <depend>rclcpp</depend>
 
   <test_depend>ament_cmake_ros</test_depend>


### PR DESCRIPTION
## Description
add fmt dependency for https://github.com/autowarefoundation/autoware_utils/blob/260bc9dc62a898fde162e0b9a65fcd78fae070d8/autoware_utils_debug/src/time_keeper.cpp#L20

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
