### PR TITLE
feat(autoware_utils_diagnostics): cutomize topic name

### DIFF
--- a/autoware_utils_diagnostics/include/autoware_utils_diagnostics/diagnostics_interface.hpp
+++ b/autoware_utils_diagnostics/include/autoware_utils_diagnostics/diagnostics_interface.hpp
@@ -27,7 +27,7 @@ namespace autoware_utils_diagnostics
 class DiagnosticsInterface
 {
 public:
-  DiagnosticsInterface(rclcpp::Node * node, const std::string & diagnostic_name);
+  DiagnosticsInterface(rclcpp::Node * node, const std::string & diagnostic_name, const std::string & diagnostic_topic_name = "/diagnostics");
   void clear();
   void add_key_value(const diagnostic_msgs::msg::KeyValue & key_value_msg);
   template <typename T>

--- a/autoware_utils_diagnostics/include/autoware_utils_diagnostics/diagnostics_interface.hpp
+++ b/autoware_utils_diagnostics/include/autoware_utils_diagnostics/diagnostics_interface.hpp
@@ -27,7 +27,9 @@ namespace autoware_utils_diagnostics
 class DiagnosticsInterface
 {
 public:
-  DiagnosticsInterface(rclcpp::Node * node, const std::string & diagnostic_name, const std::string & diagnostic_topic_name = "/diagnostics");
+  DiagnosticsInterface(
+    rclcpp::Node * node, const std::string & diagnostic_name,
+    const std::string & diagnostic_topic_name = "/diagnostics");
   void clear();
   void add_key_value(const diagnostic_msgs::msg::KeyValue & key_value_msg);
   template <typename T>

--- a/autoware_utils_diagnostics/src/diagnostics_interface.cpp
+++ b/autoware_utils_diagnostics/src/diagnostics_interface.cpp
@@ -23,7 +23,9 @@
 
 namespace autoware_utils_diagnostics
 {
-DiagnosticsInterface::DiagnosticsInterface(rclcpp::Node * node, const std::string & diagnostic_name, const std::string & diagnostic_topic_name)
+DiagnosticsInterface::DiagnosticsInterface(
+  rclcpp::Node * node, const std::string & diagnostic_name,
+  const std::string & diagnostic_topic_name)
 : clock_(node->get_clock())
 {
   diagnostics_pub_ =

--- a/autoware_utils_diagnostics/src/diagnostics_interface.cpp
+++ b/autoware_utils_diagnostics/src/diagnostics_interface.cpp
@@ -23,11 +23,11 @@
 
 namespace autoware_utils_diagnostics
 {
-DiagnosticsInterface::DiagnosticsInterface(rclcpp::Node * node, const std::string & diagnostic_name)
+DiagnosticsInterface::DiagnosticsInterface(rclcpp::Node * node, const std::string & diagnostic_name, const std::string & diagnostic_topic_name)
 : clock_(node->get_clock())
 {
   diagnostics_pub_ =
-    node->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 10);
+    node->create_publisher<diagnostic_msgs::msg::DiagnosticArray>(diagnostic_topic_name, 10);
 
   diagnostics_status_msg_.name =
     std::string(node->get_name()) + std::string(": ") + diagnostic_name;


### PR DESCRIPTION
## Description
Currently, all nodes that use the DiagnosticsInterface publish diagnostics messages to the `/diagnostics `topic.
This PR introduces support for customizing the diagnostics topic name, allowing users to publish to a different topic if needed.

For example, in [this PR](https://github.com/autowarefoundation/autoware_universe/pull/10847), the concatenate node publishes an additional diagnostics message to a separate topic intended for downstream modules.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
