### PR TITLE
refactor: set constant value for marker lifetime

### DIFF
--- a/autoware_utils_visualization/include/autoware_utils_visualization/marker_helper.hpp
+++ b/autoware_utils_visualization/include/autoware_utils_visualization/marker_helper.hpp
@@ -24,6 +24,10 @@
 
 namespace autoware_utils_visualization
 {
+
+// Constant value for marker lifetime
+inline constexpr double MARKER_LIFETIME = 0.5;
+
 inline geometry_msgs::msg::Point create_marker_position(double x, double y, double z)
 {
   geometry_msgs::msg::Point point;

--- a/autoware_utils_visualization/src/marker_helper.cpp
+++ b/autoware_utils_visualization/src/marker_helper.cpp
@@ -31,7 +31,7 @@ visualization_msgs::msg::Marker create_default_marker(
   marker.id = id;
   marker.type = type;
   marker.action = visualization_msgs::msg::Marker::ADD;
-  marker.lifetime = rclcpp::Duration::from_seconds(0.5);
+  marker.lifetime = rclcpp::Duration::from_seconds(MARKER_LIFETIME);
 
   marker.pose.position = create_marker_position(0.0, 0.0, 0.0);
   marker.pose.orientation = create_marker_orientation(0.0, 0.0, 0.0, 1.0);


### PR DESCRIPTION
## Description
The marker lifetime was previously hardcoded at the point of use. 
![image](https://github.com/user-attachments/assets/840b65aa-8e66-4947-af6b-ae4804fe610c)
Since there are various usage patterns, [we evaluated different durations ](https://docs.google.com/document/d/1t485G5QsUPSGXSx0b9Sldi833N5ygu87GggGgqX1L6Q/edit?tab=t.0)and concluded that 0.5 seconds offers a good balance — it’s short enough to avoid clutter in RViz, yet long enough to accommodate the node's publishing frequency of 10 Hz (every 0.1 seconds).

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
