### PR TITLE
fix(autoware_utils_uuid): include cstdint as uint8_t is used

### DIFF
--- a/autoware_utils_uuid/include/autoware_utils_uuid/uuid_helper.hpp
+++ b/autoware_utils_uuid/include/autoware_utils_uuid/uuid_helper.hpp
@@ -20,6 +20,7 @@
 #include <boost/uuid/uuid.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <random>
 #include <string>
 


### PR DESCRIPTION
## Description

As `uuid_helper.hpp` uses `uint8_t` type, it should include the `cstdint` header, see https://en.cppreference.com/w/cpp/types/integer.html . 

## How was this PR tested?

By compiling the project.

## Notes for reviewers

None.

## Effects on system behavior

None.
