### PR TITLE
chore: add ignore false positive maybe-uninitialized warning from boost

### DIFF
--- a/autoware_utils_geometry/include/autoware_utils_geometry/boost_geometry.hpp
+++ b/autoware_utils_geometry/include/autoware_utils_geometry/boost_geometry.hpp
@@ -18,8 +18,9 @@
 // Suppress boost geometry uninitialized variable warnings
 // This is a known issue in boost geometry library where internal template code
 // may trigger maybe-uninitialized warnings that are false positives.
-// Related: https://www.boost.org/doc/libs/latest/libs/utility/doc/html/utility/utilities/value_init.html
-// and https://www.boost.org/doc/libs/1_89_0/libs/optional/doc/html/boost_optional/design/gotchas/false_positive_with__wmaybe_uninitialized.html
+// Related:
+// https://www.boost.org/doc/libs/latest/libs/utility/doc/html/utility/utilities/value_init.html and
+// https://www.boost.org/doc/libs/1_89_0/libs/optional/doc/html/boost_optional/design/gotchas/false_positive_with__wmaybe_uninitialized.html
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"

--- a/autoware_utils_geometry/include/autoware_utils_geometry/boost_geometry.hpp
+++ b/autoware_utils_geometry/include/autoware_utils_geometry/boost_geometry.hpp
@@ -15,10 +15,24 @@
 #ifndef AUTOWARE_UTILS_GEOMETRY__BOOST_GEOMETRY_HPP_
 #define AUTOWARE_UTILS_GEOMETRY__BOOST_GEOMETRY_HPP_
 
+// Suppress boost geometry uninitialized variable warnings
+// This is a known issue in boost geometry library where internal template code
+// may trigger maybe-uninitialized warnings that are false positives.
+// Related: https://www.boost.org/doc/libs/latest/libs/utility/doc/html/utility/utilities/value_init.html
+// and https://www.boost.org/doc/libs/1_89_0/libs/optional/doc/html/boost_optional/design/gotchas/false_positive_with__wmaybe_uninitialized.html
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/geometries/geometries.hpp>
 #include <boost/geometry/geometries/register/point.hpp>
 #include <boost/geometry/geometries/register/ring.hpp>
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #define EIGEN_MPL2_ONLY
 #include <Eigen/Core>


### PR DESCRIPTION
## Description
Autoware build-and-test workflow is failing on jazzy due to false positive error from boost library. 
This PR will ignore the error. 
https://github.com/autowarefoundation/autoware_core/actions/runs/23329785827/job/67888933261

Related link: https://github.com/autowarefoundation/autoware/issues/6695

## How was this PR tested?
Tested locally using jazzy docker image.

```
git clone https://github.com/autowarefoundation/autoware.git autoware_jazzy
cd autoware_jazzy
vcs import src/ < repositories/autoware.repos
vcs import src/ < repositories/autoware-nightly.repos

docker run -it --name autoware_jazzy --rm -v $HOME/autoware_jazzy:/autoware_jazzy ghcr.io/autowarefoundation/autoware:universe-devel-jazzy-amd64 /bin/bash

# within docker image
sudo apt update
rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO
colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS='--coverage'
```

## Notes for reviewers

None.

## Effects on system behavior

None.
