### PR TITLE
refactor(autoware_utils): add USE_SCOPED_HEADER_INSTALL_DIR

### DIFF
--- a/autoware_utils/CMakeLists.txt
+++ b/autoware_utils/CMakeLists.txt
@@ -3,4 +3,4 @@ project(autoware_utils)
 
 find_package(autoware_cmake REQUIRED)
 autoware_package()
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_utils/CMakeLists.txt
+++ b/autoware_utils/CMakeLists.txt
@@ -3,4 +3,4 @@ project(autoware_utils)
 
 find_package(autoware_cmake REQUIRED)
 autoware_package()
-ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)
+autoware_ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_utils_debug/CMakeLists.txt
+++ b/autoware_utils_debug/CMakeLists.txt
@@ -18,4 +18,4 @@ if(BUILD_TESTING)
   target_link_libraries(test_${PROJECT_NAME} ${PROJECT_NAME})
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_utils_diagnostics/CMakeLists.txt
+++ b/autoware_utils_diagnostics/CMakeLists.txt
@@ -18,4 +18,4 @@ if(BUILD_TESTING)
   target_link_libraries(test_${PROJECT_NAME} ${PROJECT_NAME})
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_utils_geometry/CMakeLists.txt
+++ b/autoware_utils_geometry/CMakeLists.txt
@@ -23,4 +23,4 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(test_${PROJECT_NAME} ${test_files})
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_utils_logging/CMakeLists.txt
+++ b/autoware_utils_logging/CMakeLists.txt
@@ -16,4 +16,4 @@ if(BUILD_TESTING)
   target_link_libraries(test_${PROJECT_NAME} ${PROJECT_NAME})
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_utils_math/CMakeLists.txt
+++ b/autoware_utils_math/CMakeLists.txt
@@ -14,4 +14,4 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(test_${PROJECT_NAME} ${test_files})
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_utils_pcl/CMakeLists.txt
+++ b/autoware_utils_pcl/CMakeLists.txt
@@ -9,4 +9,4 @@ if(BUILD_TESTING)
 
   ament_auto_add_gtest(test_${PROJECT_NAME} ${test_files})
 endif()
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_utils_rclcpp/CMakeLists.txt
+++ b/autoware_utils_rclcpp/CMakeLists.txt
@@ -9,4 +9,4 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(test_${PROJECT_NAME} ${test_files})
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_utils_system/CMakeLists.txt
+++ b/autoware_utils_system/CMakeLists.txt
@@ -13,4 +13,4 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(test_${PROJECT_NAME} ${test_files})
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_utils_tf/CMakeLists.txt
+++ b/autoware_utils_tf/CMakeLists.txt
@@ -14,4 +14,4 @@ if(BUILD_TESTING)
   target_include_directories(test_${PROJECT_NAME} PRIVATE include)
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_utils_uuid/CMakeLists.txt
+++ b/autoware_utils_uuid/CMakeLists.txt
@@ -9,4 +9,4 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(test_${PROJECT_NAME} ${test_files})
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_utils_visualization/CMakeLists.txt
+++ b/autoware_utils_visualization/CMakeLists.txt
@@ -13,4 +13,4 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(test_${PROJECT_NAME} ${test_files})
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)


### PR DESCRIPTION
## Description

This PR adds `USE_SCOPED_HEADER_INSTALL_DIR` to existing `ament_auto_package()` calls in `autoware_utils`.

Updated packages:
- `autoware_utils`
- `autoware_utils_debug`
- `autoware_utils_diagnostics`
- `autoware_utils_geometry`
- `autoware_utils_logging`
- `autoware_utils_math`
- `autoware_utils_pcl`
- `autoware_utils_rclcpp`
- `autoware_utils_system`
- `autoware_utils_tf`
- `autoware_utils_uuid`
- `autoware_utils_visualization`

## How was this PR tested?

Built the target packages locally:
```bash
colcon build --base-paths ~/autoware_scoped_headers/autoware/src \
  --symlink-install \
  --cmake-args -DCMAKE_BUILD_TYPE=Release \
  --packages-select \
  autoware_utils \
  autoware_utils_debug \
  autoware_utils_diagnostics \
  autoware_utils_geometry \
  autoware_utils_logging \
  autoware_utils_math \
  autoware_utils_pcl \
  autoware_utils_rclcpp \
  autoware_utils_system \
  autoware_utils_tf \
  autoware_utils_uuid \
  autoware_utils_visualization
```

## Notes for reviewers

This is part of the follow-up work after adding `USE_SCOPED_HEADER_INSTALL_DIR` support to `autoware_cmake`.

## Interface changes

None.

## Effects on system behavior

No functional behavior change. This updates the package macro options for the scoped header installation migration.