### PR TITLE
feat: support template publisher for TimeKeeper

### DIFF
--- a/autoware_utils_debug/include/autoware_utils_debug/time_keeper.hpp
+++ b/autoware_utils_debug/include/autoware_utils_debug/time_keeper.hpp
@@ -149,9 +149,8 @@ public:
    * rclcpp publisher SharedPtr handled by the non-template overload above.
    */
   template <typename PublisherT>
-  auto add_reporter(std::shared_ptr<PublisherT> publisher) -> std::enable_if_t<
-    !std::is_same_v<
-      std::shared_ptr<PublisherT>, rclcpp::Publisher<ProcessingTimeDetail>::SharedPtr>>
+  auto add_reporter(std::shared_ptr<PublisherT> publisher) -> std::enable_if_t<!std::is_same_v<
+    std::shared_ptr<PublisherT>, rclcpp::Publisher<ProcessingTimeDetail>::SharedPtr>>
   {
     reporters_.emplace_back(
       [publisher = std::move(publisher)](const std::shared_ptr<ProcessingTimeNode> & node) {

--- a/autoware_utils_debug/include/autoware_utils_debug/time_keeper.hpp
+++ b/autoware_utils_debug/include/autoware_utils_debug/time_keeper.hpp
@@ -143,6 +143,23 @@ public:
   void add_reporter(rclcpp::Publisher<ProcessingTimeDetail>::SharedPtr publisher);
 
   /**
+   * @brief Add a reporter that publishes through any publisher-like handle.
+   * Accepts custom publishers (e.g. autoware::agnocast_wrapper::Publisher) that expose a
+   * compatible publish(ProcessingTimeDetail) method. Enabled only when the handle is not the
+   * rclcpp publisher SharedPtr handled by the non-template overload above.
+   */
+  template <typename PublisherT>
+  auto add_reporter(std::shared_ptr<PublisherT> publisher) -> std::enable_if_t<
+    !std::is_same_v<
+      std::shared_ptr<PublisherT>, rclcpp::Publisher<ProcessingTimeDetail>::SharedPtr>>
+  {
+    reporters_.emplace_back(
+      [publisher = std::move(publisher)](const std::shared_ptr<ProcessingTimeNode> & node) {
+        publisher->publish(node->to_msg());
+      });
+  }
+
+  /**
    * @brief Start tracking the processing time of a function
    *
    * @param func_name Name of the function to be tracked

--- a/autoware_utils_debug/include/autoware_utils_debug/time_keeper.hpp
+++ b/autoware_utils_debug/include/autoware_utils_debug/time_keeper.hpp
@@ -26,6 +26,8 @@
 #include <ostream>
 #include <string>
 #include <thread>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace autoware_utils_debug


### PR DESCRIPTION
## Description
Add a template `add_reporter` overload to `TimeKeeper` so publishers other than `rclcpp::Publisher` (e.g. `autoware::agnocast_wrapper::Publisher`) can also be used as reporters.

This adds a templated `add_reporter` overload to `autoware_utils_debug::TimeKeeper` that accepts any `std::shared_ptr<PublisherT>` exposing a `publish(ProcessingTimeDetail)` method. The existing `rclcpp::Publisher` overload is kept unchanged, so this is an additive, ABI-compatible change. The motivation is to let nodes inheriting from `autoware::agnocast_wrapper::Node` use `TimeKeeper` with the publisher returned by the wrapper's `create_publisher`. 

## How was this PR tested?
Built and confirmed existing code.

## Notes for reviewers
Autoware Discussion to introduce `agnocast::Node`.
https://github.com/orgs/autowarefoundation/discussions/6804

## Effects on system behavior
No behavior change. Existing code remains compatible via the type alias.