### PR TITLE
test(autoware_utils_system): cover LRUCache get/clear/size/empty/capacity and LRU reorder

### DIFF
--- a/autoware_utils_system/test/cases/lru_cache.cpp
+++ b/autoware_utils_system/test/cases/lru_cache.cpp
@@ -51,3 +51,87 @@ INSTANTIATE_TEST_SUITE_P(
     ParamLruCache{4, {1, 2, 3, 4, 5, 6}, {3, 4, 5, 6}},
     ParamLruCache{4, {1, 2, 3, 1, 4, 5}, {1, 3, 4, 5}},
     ParamLruCache{4, {1, 2, 3, 2, 4, 5}, {2, 3, 4, 5}}));
+
+// get() on a present key returns the stored value.
+TEST(LruCache, GetHitReturnsValue)
+{
+  autoware_utils_system::LRUCache<int, std::string> cache(3);
+  cache.put(1, "one");
+  const auto value = cache.get(1);
+  ASSERT_TRUE(value.has_value());
+  EXPECT_EQ(*value, "one");
+}
+
+// get() on a missing key returns std::nullopt.
+TEST(LruCache, GetMissReturnsNullopt)
+{
+  autoware_utils_system::LRUCache<int, std::string> cache(3);
+  cache.put(1, "one");
+  EXPECT_FALSE(cache.get(99).has_value());
+}
+
+// get() refreshes recency: the accessed key must survive eviction (splice-to-front).
+TEST(LruCache, GetRefreshesRecency)
+{
+  autoware_utils_system::LRUCache<int, std::string> cache(3);
+  cache.put(1, "one");
+  cache.put(2, "two");
+  cache.put(3, "three");
+  // Access key 1 so it becomes most-recently-used; the least-recently-used is now 2.
+  ASSERT_TRUE(cache.get(1).has_value());
+  // Exceeding capacity must evict 2, not 1.
+  cache.put(4, "four");
+  EXPECT_TRUE(cache.contains(1));
+  EXPECT_FALSE(cache.contains(2));
+  EXPECT_TRUE(cache.contains(3));
+  EXPECT_TRUE(cache.contains(4));
+}
+
+// put() on an existing key overwrites the value and refreshes recency.
+TEST(LruCache, PutExistingKeyOverwritesAndRefreshes)
+{
+  autoware_utils_system::LRUCache<int, std::string> cache(2);
+  cache.put(1, "a");
+  cache.put(2, "b");
+  // Re-put key 1: value becomes "c" and 1 becomes most-recently-used, so 2 is now LRU.
+  cache.put(1, "c");
+  cache.put(3, "d");  // exceeds capacity -> evicts 2
+  const auto value = cache.get(1);
+  ASSERT_TRUE(value.has_value());
+  EXPECT_EQ(*value, "c");
+  EXPECT_FALSE(cache.contains(2));
+  EXPECT_TRUE(cache.contains(3));
+}
+
+// clear() empties the cache.
+TEST(LruCache, ClearEmptiesCache)
+{
+  autoware_utils_system::LRUCache<int, std::string> cache(3);
+  cache.put(1, "one");
+  cache.put(2, "two");
+  cache.clear();
+  EXPECT_EQ(cache.size(), 0u);
+  EXPECT_TRUE(cache.empty());
+  EXPECT_FALSE(cache.contains(1));
+  EXPECT_FALSE(cache.get(1).has_value());
+}
+
+// size()/empty()/capacity() report consistent values and size never exceeds capacity.
+TEST(LruCache, SizeEmptyCapacity)
+{
+  autoware_utils_system::LRUCache<int, std::string> cache(3);
+  EXPECT_EQ(cache.capacity(), 3u);
+  EXPECT_TRUE(cache.empty());
+  EXPECT_EQ(cache.size(), 0u);
+
+  cache.put(1, "one");
+  cache.put(2, "two");
+  EXPECT_EQ(cache.size(), 2u);
+  EXPECT_FALSE(cache.empty());
+
+  // Overflow the capacity; size must cap at the configured capacity.
+  cache.put(3, "three");
+  cache.put(4, "four");
+  EXPECT_EQ(cache.size(), 3u);
+  EXPECT_EQ(cache.capacity(), 3u);
+}


### PR DESCRIPTION
## Why

The header-only `LRUCache` in `autoware_utils_system/include/autoware_utils_system/lru_cache.hpp` was only partially tested. The existing parameterized test (`test/cases/lru_cache.cpp`) exercised `put()` and `contains()` through an eviction scenario, but `get()`, the LRU-reorder side effect of `get()` (splice-to-front), `clear()`, `size()`, `empty()`, and `capacity()` were entirely untested.

## What

Coverage-only PR. Adds six new gtest cases to the existing `test/cases/lru_cache.cpp` that assert concrete values and branches (no bare `EXPECT_NO_THROW`):

1. `GetHitReturnsValue` — `get()` on a present key returns the stored value.
2. `GetMissReturnsNullopt` — `get()` on a missing key returns `std::nullopt`.
3. `GetRefreshesRecency` — accessing a key via `get()` moves it to the front, so a later capacity-exceeding `put()` evicts the next-LRU key, not the accessed one (pins the `splice` behavior).
4. `PutExistingKeyOverwritesAndRefreshes` — re-`put()` of an existing key overwrites the value and refreshes recency.
5. `ClearEmptiesCache` — after `clear()`, `size()==0`, `empty()`, key no longer present, `get()` returns nullopt.
6. `SizeEmptyCapacity` — `capacity()`/`empty()`/`size()` invariants; size never exceeds capacity on overflow.

No production code changed; `lru_cache.hpp` is untouched. The new tests are picked up automatically by the existing `file(GLOB_RECURSE test_files test/*.cpp)` + `ament_auto_add_gtest` wiring, so no CMake change was needed.

## Verification

Built and tested in the `autoware:universe-devel-jazzy` container: `colcon build` + `colcon test` for `autoware_utils_system` is green. All 6 new `LruCache` tests pass; the full suite reports 40 tests, 0 errors, 0 failures (copyright, cppcheck, lint_cmake, xmllint linters pass). `pre-commit` (clang-format, cpplint) passes on the changed file.


---

## youtalk fork CI — build-and-test all green

Verified green on the youtalk fork before submission (fork PR youtalk/autoware_utils#1):

- `build-and-test-differential (humble)`: https://github.com/youtalk/autoware_utils/actions/runs/26824790767/job/79089053027 ✅
- `build-and-test-differential (jazzy)`: https://github.com/youtalk/autoware_utils/actions/runs/26824790767/job/79089052980 ✅
- `spell-check-differential`: ✅
