### PR TITLE
perf(autoware_utils_diagnostics): drop per-cycle shrink_to_fit in clear()

### DIFF
--- a/autoware_utils_diagnostics/include/autoware_utils_diagnostics/diagnostics_interface.hpp
+++ b/autoware_utils_diagnostics/include/autoware_utils_diagnostics/diagnostics_interface.hpp
@@ -48,7 +48,6 @@ public:
   void clear()
   {
     diagnostics_status_msg_.values.clear();
-    diagnostics_status_msg_.values.shrink_to_fit();
 
     diagnostics_status_msg_.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
     diagnostics_status_msg_.message = "";

--- a/autoware_utils_diagnostics/test/cases/diagnostics_interface.cpp
+++ b/autoware_utils_diagnostics/test/cases/diagnostics_interface.cpp
@@ -14,12 +14,148 @@
 
 #include "autoware_utils_diagnostics/diagnostics_interface.hpp"
 
+#include <rclcpp/rclcpp.hpp>
+
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
 
 TEST(TestDiagnosticsInterface, Instantiation)
 {
   const auto node = std::make_shared<rclcpp::Node>("test_node");
   autoware_utils_diagnostics::DiagnosticsInterface(node.get(), "diag_name");
+}
+
+// Characterization test that pins the observable behavior of DiagnosticsInterface across
+// clear() cycles. It proves that publishing produces output-identical messages whether or not
+// clear() releases the underlying buffer (i.e. the per-cycle shrink_to_fit removal is
+// behavior-preserving). It mirrors the executor-in-thread pattern from
+// autoware_utils_rclcpp/test/cases/polling_subscriber.cpp.
+TEST(TestDiagnosticsInterface, PubSubAcrossClearCycles)
+{
+  const auto node = std::make_shared<rclcpp::Node>("test_diag_pubsub");
+  autoware_utils_diagnostics::DiagnosticsInterface diag(node.get(), "diag_name");
+
+  std::mutex mutex;
+  std::optional<diagnostic_msgs::msg::DiagnosticArray> last_received;
+  [[maybe_unused]] const auto sub =
+    node->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+      "/diagnostics", rclcpp::QoS(10),
+      [&mutex, &last_received](const diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg) {
+        std::lock_guard<std::mutex> lock(mutex);
+        last_received = *msg;
+      });
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  std::thread thread([&executor] { executor.spin(); });
+
+  // Ensure the executor is always stopped and the thread joined, even when a gtest
+  // ASSERT_* early-returns; otherwise a joinable std::thread destructor would call
+  // std::terminate() and mask the real failure.
+  struct ExecutorStopGuard
+  {
+    rclcpp::executors::SingleThreadedExecutor & exec;
+    std::thread & th;
+    ~ExecutorStopGuard()
+    {
+      exec.cancel();
+      if (th.joinable()) {
+        th.join();
+      }
+    }
+  } stop_guard{executor, thread};
+
+  while (rclcpp::ok() && !executor.is_spinning()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  // Helper that waits until a message is received after a publish (or fails on timeout).
+  const auto wait_for_message =
+    [&mutex, &last_received]() -> std::optional<diagnostic_msgs::msg::DiagnosticArray> {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (std::chrono::steady_clock::now() < deadline) {
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (last_received.has_value()) {
+          return last_received;
+        }
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return std::nullopt;
+  };
+
+  const auto reset_received = [&mutex, &last_received]() {
+    std::lock_guard<std::mutex> lock(mutex);
+    last_received.reset();
+  };
+
+  // Cycle 1: populate values, raise level to WARN with a message, then publish.
+  {
+    reset_received();
+    diag.add_key_value("k1", std::string("v1"));
+    diag.add_key_value("k2", 3);
+    diag.update_level_and_message(diagnostic_msgs::msg::DiagnosticStatus::WARN, "warn-msg");
+    diag.publish(node->now());
+
+    const auto received = wait_for_message();
+    ASSERT_TRUE(received.has_value()) << "Cycle 1 message was not received within the timeout";
+
+    const auto & status = received->status;
+    ASSERT_EQ(status.size(), 1u);
+    ASSERT_EQ(status[0].values.size(), 2u);
+    EXPECT_EQ(status[0].values[0].key, "k1");
+    EXPECT_EQ(status[0].values[0].value, "v1");
+    EXPECT_EQ(status[0].values[1].key, "k2");
+    EXPECT_EQ(status[0].values[1].value, "3");
+    EXPECT_EQ(status[0].level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
+    EXPECT_EQ(status[0].message, "warn-msg");
+  }
+
+  // Cycle 2: clear() must empty the values (regardless of shrink_to_fit), reset level to OK and
+  // let create_diagnostics_array rewrite the message to "OK".
+  {
+    reset_received();
+    diag.clear();
+    diag.add_key_value("k3", std::string("v3"));
+    diag.publish(node->now());
+
+    const auto received = wait_for_message();
+    ASSERT_TRUE(received.has_value()) << "Cycle 2 message was not received within the timeout";
+
+    const auto & status = received->status;
+    ASSERT_EQ(status.size(), 1u);
+    ASSERT_EQ(status[0].values.size(), 1u);
+    EXPECT_EQ(status[0].values[0].key, "k3");
+    EXPECT_EQ(status[0].values[0].value, "v3");
+    EXPECT_EQ(status[0].level, diagnostic_msgs::msg::DiagnosticStatus::OK);
+    EXPECT_EQ(status[0].message, "OK");
+  }
+
+  // Duplicate key: re-adding an existing key overwrites the value instead of appending a new entry.
+  {
+    reset_received();
+    diag.clear();
+    diag.add_key_value("k1", std::string("a"));
+    diag.add_key_value("k1", std::string("b"));
+    diag.publish(node->now());
+
+    const auto received = wait_for_message();
+    ASSERT_TRUE(received.has_value()) << "duplicate-key message not received within the timeout";
+
+    const auto & status = received->status;
+    ASSERT_EQ(status.size(), 1u);
+    ASSERT_EQ(status[0].values.size(), 1u);
+    EXPECT_EQ(status[0].values[0].key, "k1");
+    EXPECT_EQ(status[0].values[0].value, "b");
+  }
 }


### PR DESCRIPTION
## What

Remove the `diagnostics_status_msg_.values.shrink_to_fit()` call from
`BasicDiagnosticsInterface::clear()` in
`autoware_utils_diagnostics/include/autoware_utils_diagnostics/diagnostics_interface.hpp`.

## Why

`clear()` called `values.shrink_to_fit()` immediately after `values.clear()`,
releasing the underlying vector buffer on every cycle. On hot localization
callbacks this forces the next `add_key_value()` `push_back`s to reallocate the
buffer each cycle. Dropping `shrink_to_fit()` lets the small capacity persist
across cycles, eliminating the per-cycle heap churn.

`values.clear()` and the `level` / `message` resets are kept unchanged, so the
published `DiagnosticArray` messages are output-identical. No `reserve()` is
added (out of scope).

## Behavior

Output-identical. The only change is internal: the values vector retains its
capacity across `clear()` cycles instead of releasing it.

## Tests

The existing `test/cases/diagnostics_interface.cpp` only instantiated the class
with no assertions. Added a real pub/sub characterization test
(`PubSubAcrossClearCycles`) that pins observable behavior across `clear()`
cycles, mirroring the executor-in-thread pattern from
`autoware_utils_rclcpp/test/cases/polling_subscriber.cpp`:

- Cycle 1: asserts `status.size()==1`, exactly `{(k1,v1),(k2,3)}` in insertion
  order, `level==WARN`, `message==\"warn-msg\"`.
- Cycle 2 (the `clear()` guard): asserts `clear()` empties values regardless of
  the removed `shrink_to_fit()` — exactly `{(k3,v3)}`, `level==OK`,
  `message==\"OK\"` (rewritten by `create_diagnostics_array`).
- Dedup: re-adding key `k1` overwrites to a single entry with value `\"b\"`.

All assertions use concrete values; the subscriber callback stores the last
received `DiagnosticArray` and the test spins/sleeps with a 5 s timeout (fails if
not received).

Built and tested in `autoware:universe-devel-jazzy`: build green, all 3 gtest
cases pass, copyright / cppcheck / lint_cmake / xmllint pass. pre-commit
(clang-format, cpplint) clean.


---

## youtalk fork CI — build-and-test all green

Verified green on the youtalk fork before submission (fork PR youtalk/autoware_utils#4):

- `build-and-test-differential (humble)`: https://github.com/youtalk/autoware_utils/actions/runs/26827860400/job/79100425904 ✅
- `build-and-test-differential (jazzy)`: https://github.com/youtalk/autoware_utils/actions/runs/26827860400/job/79100425921 ✅
- `spell-check-differential`: ✅
