### PR TITLE
test(autoware_utils_rclcpp): cover check_qos depth>1 throw for Latest/Newest

### DIFF
--- a/autoware_utils_rclcpp/test/cases/polling_subscriber.cpp
+++ b/autoware_utils_rclcpp/test/cases/polling_subscriber.cpp
@@ -20,7 +20,53 @@
 
 #include <chrono>
 #include <memory>
+#include <stdexcept>
 #include <thread>
+
+// Type aliases keep the template comma out of the gtest macro argument list.
+using LatestStringSub = autoware_utils_rclcpp::InterProcessPollingSubscriber<
+  std_msgs::msg::String, autoware_utils_rclcpp::polling_policy::Latest>;
+using NewestStringSub = autoware_utils_rclcpp::InterProcessPollingSubscriber<
+  std_msgs::msg::String, autoware_utils_rclcpp::polling_policy::Newest>;
+using AllStringSub = autoware_utils_rclcpp::InterProcessPollingSubscriber<
+  std_msgs::msg::String, autoware_utils_rclcpp::polling_policy::All>;
+
+TEST(TestPollingSubscriber, CheckQosDepthGreaterThanOneThrows)
+{
+  const auto node = std::make_shared<rclcpp::Node>("test_check_qos_throw");
+
+  // Latest/Newest reject QoS depth > 1: polling needs a single-depth queue, so a deeper
+  // queue is rejected at construction.
+  EXPECT_THROW(
+    LatestStringSub::create_subscription(node.get(), "/test/latest_deep", rclcpp::QoS{10}),
+    std::invalid_argument);
+
+  // Newest policy rejects QoS depth > 1 for the same reason.
+  EXPECT_THROW(
+    NewestStringSub::create_subscription(node.get(), "/test/newest_deep", rclcpp::QoS{10}),
+    std::invalid_argument);
+}
+
+TEST(TestPollingSubscriber, CheckQosDepthOneDoesNotThrow)
+{
+  const auto node = std::make_shared<rclcpp::Node>("test_check_qos_no_throw");
+
+  // QoS depth == 1 is the allowed boundary for Latest.
+  EXPECT_NO_THROW(
+    LatestStringSub::create_subscription(node.get(), "/test/latest_shallow", rclcpp::QoS{1}));
+
+  // QoS depth == 1 is the allowed boundary for Newest.
+  EXPECT_NO_THROW(
+    NewestStringSub::create_subscription(node.get(), "/test/newest_shallow", rclcpp::QoS{1}));
+}
+
+TEST(TestPollingSubscriber, CheckQosAllPolicyIgnoresDepth)
+{
+  const auto node = std::make_shared<rclcpp::Node>("test_check_qos_all");
+
+  // All policy's check_qos is a no-op, so a deep QoS must not throw.
+  EXPECT_NO_THROW(AllStringSub::create_subscription(node.get(), "/test/all_deep", rclcpp::QoS{10}));
+}
 
 TEST(TestPollingSubscriber, InitialValues)
 {


### PR DESCRIPTION
## Why

The QoS-validation branch in `InterProcessPollingSubscriber`'s `check_qos()` (invoked from the constructor in `autoware_utils_rclcpp/include/autoware_utils_rclcpp/polling_subscriber.hpp`, line ~208) was uncovered. Existing tests only constructed subscribers with `depth == 1`, or used the `All` policy with `QoS{10}` (whose `check_qos` is a no-op). As a result:

- The `throw std::invalid_argument` path for `polling_policy::Latest` and `polling_policy::Newest` when `qos.get_rmw_qos_profile().depth > 1` was never exercised.
- The `All` deep-QoS no-throw path (where `check_qos` ignores depth) was also dark.

## What

Adds three gtest cases to `test/cases/polling_subscriber.cpp` that assert the branch directly:

- `CheckQosDepthGreaterThanOneThrows`: `Latest` and `Newest` construction with `rclcpp::QoS{10}` throws `std::invalid_argument`.
- `CheckQosDepthOneDoesNotThrow`: `Latest` and `Newest` construction with `rclcpp::QoS{1}` (depth == 1, the allowed boundary) does not throw.
- `CheckQosAllPolicyIgnoresDepth`: `All` construction with `rclcpp::QoS{10}` does not throw, since its `check_qos` is a no-op.

Type aliases (`LatestStringSub`, `NewestStringSub`, `AllStringSub`) are introduced so the subscriber template's comma does not break the gtest `EXPECT_THROW` / `EXPECT_NO_THROW` macro argument lists.

No production code is changed. All existing tests are kept.

## Verification

Built and tested in the `autoware:universe-devel-jazzy` container: `colcon build` + `colcon test` for `autoware_utils_rclcpp` pass (10/10 gtest cases green, all linters including copyright/cppcheck/lint_cmake/xmllint pass). clang-format applied.


---

## youtalk fork CI — build-and-test all green

Verified green on the youtalk fork before submission (fork PR youtalk/autoware_utils#5):

- `build-and-test-differential (humble)`: https://github.com/youtalk/autoware_utils/actions/runs/26827854286/job/79100399237 ✅
- `build-and-test-differential (jazzy)`: https://github.com/youtalk/autoware_utils/actions/runs/26827854286/job/79100399167 ✅
- `spell-check-differential`: ✅
