### PR TITLE
feat(autoware_utils_rclcpp): templatize NodeT for `get_or_declare_parameter`

### DIFF
--- a/autoware_utils_rclcpp/include/autoware_utils_rclcpp/parameter.hpp
+++ b/autoware_utils_rclcpp/include/autoware_utils_rclcpp/parameter.hpp
@@ -25,14 +25,17 @@
 namespace autoware_utils_rclcpp
 {
 
-template <class T>
-T get_or_declare_parameter(rclcpp::Node & node, const std::string & name)
+// Templated on the node type so it also accepts non-rclcpp::Node nodes that expose the same
+// parameter API (e.g. autoware::agnocast_wrapper::Node). NodeT defaults to rclcpp::Node, so existing
+// callers (get_or_declare_parameter<T>(node, name)) are unchanged.
+template <class T, class NodeT = rclcpp::Node>
+T get_or_declare_parameter(NodeT & node, const std::string & name)
 {
   if (node.has_parameter(name)) {
-    return node.get_parameter(name).get_value<T>();
+    return node.get_parameter(name).template get_value<T>();
   }
 
-  return node.declare_parameter<T>(name);
+  return node.template declare_parameter<T>(name);
 }
 
 template <class T>

--- a/autoware_utils_rclcpp/include/autoware_utils_rclcpp/parameter.hpp
+++ b/autoware_utils_rclcpp/include/autoware_utils_rclcpp/parameter.hpp
@@ -26,8 +26,8 @@ namespace autoware_utils_rclcpp
 {
 
 // Templated on the node type so it also accepts non-rclcpp::Node nodes that expose the same
-// parameter API (e.g. autoware::agnocast_wrapper::Node). NodeT defaults to rclcpp::Node, so existing
-// callers (get_or_declare_parameter<T>(node, name)) are unchanged.
+// parameter API (e.g. autoware::agnocast_wrapper::Node). NodeT defaults to rclcpp::Node, so
+// existing callers (get_or_declare_parameter<T>(node, name)) are unchanged.
 template <class T, class NodeT = rclcpp::Node>
 T get_or_declare_parameter(NodeT & node, const std::string & name)
 {

--- a/autoware_utils_rclcpp/include/autoware_utils_rclcpp/parameter.hpp
+++ b/autoware_utils_rclcpp/include/autoware_utils_rclcpp/parameter.hpp
@@ -25,9 +25,6 @@
 namespace autoware_utils_rclcpp
 {
 
-// Templated on the node type so it also accepts non-rclcpp::Node nodes that expose the same
-// parameter API (e.g. autoware::agnocast_wrapper::Node). NodeT defaults to rclcpp::Node, so
-// existing callers (get_or_declare_parameter<T>(node, name)) are unchanged.
 template <class T, class NodeT = rclcpp::Node>
 T get_or_declare_parameter(NodeT & node, const std::string & name)
 {


### PR DESCRIPTION
## Description

Templatize the node type of `get_or_declare_parameter` so it accepts any node that exposes the same parameter API (`has_parameter` / `get_parameter` / `declare_parameter`), not only `rclcpp::Node`.

Previously the function signature hard-coded `rclcpp::Node &`, which prevented passing nodes such as `autoware::agnocast_wrapper::Node` that are not derived from `rclcpp::Node` but provide an equivalent parameter interface.

`NodeT` defaults to `rclcpp::Node`, so existing call sites (`get_or_declare_parameter<T>(node, name)`) are unaffected. Member calls are updated to the dependent-name form (`.template get_value<T>()`, `.template declare_parameter<T>()`) as required for the now-templated node type.

## How was this PR tested?

Confirmed existing callers compile unchanged, and that the templated function can now be instantiated with a non-`rclcpp::Node` node type providing the same parameter API.

## Notes for reviewers

None.

## Effects on system behavior

None.