### PR TITLE
fix(autoware_utils_system): guard backtrace on MSVC

### DIFF
--- a/autoware_utils_system/src/backtrace.cpp
+++ b/autoware_utils_system/src/backtrace.cpp
@@ -16,7 +16,9 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#if !defined(_MSC_VER)
 #include <execinfo.h>
+#endif
 
 #include <iostream>
 #include <memory>
@@ -29,6 +31,7 @@ namespace autoware_utils_system
 // cppcheck-suppress unusedFunction
 void print_backtrace()
 {
+#if !defined(_MSC_VER)
   constexpr size_t max_frames = 100;
   void * addrlist[max_frames + 1];
 
@@ -49,5 +52,9 @@ void print_backtrace()
 
   free(symbol_list);
 }
+#else
+  return;
+}
+#endif
 
 }  // namespace autoware_utils_system


### PR DESCRIPTION
## Description

This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-autoware-utils-system.win.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: `autoware_utils_system` uses `execinfo.h` and the backtrace APIs, which are not available with MSVC. Guarding the POSIX implementation keeps the package buildable on Windows while preserving the current behavior on platforms that provide `execinfo`.

## How was this PR tested?

Not run locally for this upstreaming batch; relying on upstream CI.

## Notes for reviewers

Related RoboStack upstreaming tracker: https://github.com/RoboStack/robostack.github.io/issues/16

## Effects on system behavior

None.
