### PR TITLE
feat(autoware_utils_geometry): improve boost_polygon_utils to guard against degenerate inputs

### DIFF
--- a/autoware_utils_geometry/include/autoware_utils_geometry/boost_polygon_utils.hpp
+++ b/autoware_utils_geometry/include/autoware_utils_geometry/boost_polygon_utils.hpp
@@ -38,10 +38,18 @@ Polygon2d rotate_polygon(const Polygon2d & polygon, const double angle);
 Polygon2d to_polygon2d(
   const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape);
 Polygon2d to_polygon2d(
-  const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape);
+  const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape,
+  const double buffer);
 Polygon2d to_polygon2d(const autoware_perception_msgs::msg::DetectedObject & object);
 Polygon2d to_polygon2d(const autoware_perception_msgs::msg::TrackedObject & object);
 Polygon2d to_polygon2d(const autoware_perception_msgs::msg::PredictedObject & object);
+
+Polygon2d to_polygon2d(
+  const autoware_perception_msgs::msg::DetectedObject & object, const double buffer);
+Polygon2d to_polygon2d(
+  const autoware_perception_msgs::msg::TrackedObject & object, const double buffer);
+Polygon2d to_polygon2d(
+  const autoware_perception_msgs::msg::PredictedObject & object, const double buffer);
 Polygon2d to_footprint(
   const geometry_msgs::msg::Pose & base_link_pose, const double base_to_front,
   const double base_to_rear, const double width);

--- a/autoware_utils_geometry/include/autoware_utils_geometry/boost_polygon_utils.hpp
+++ b/autoware_utils_geometry/include/autoware_utils_geometry/boost_polygon_utils.hpp
@@ -35,14 +35,26 @@ geometry_msgs::msg::Polygon rotate_polygon(
 /// @param[in] angle angle of rotation [rad]
 /// @return rotated polygon
 Polygon2d rotate_polygon(const Polygon2d & polygon, const double angle);
+
 Polygon2d to_polygon2d(
   const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape);
+Polygon2d to_polygon2d_safe(
+  const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape);
+
 Polygon2d to_polygon2d(
   const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape,
   const double buffer);
+Polygon2d to_polygon2d_safe(
+  const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape,
+  const double buffer);
+
 Polygon2d to_polygon2d(const autoware_perception_msgs::msg::DetectedObject & object);
 Polygon2d to_polygon2d(const autoware_perception_msgs::msg::TrackedObject & object);
 Polygon2d to_polygon2d(const autoware_perception_msgs::msg::PredictedObject & object);
+
+Polygon2d to_polygon2d_safe(const autoware_perception_msgs::msg::DetectedObject & object);
+Polygon2d to_polygon2d_safe(const autoware_perception_msgs::msg::TrackedObject & object);
+Polygon2d to_polygon2d_safe(const autoware_perception_msgs::msg::PredictedObject & object);
 
 Polygon2d to_polygon2d(
   const autoware_perception_msgs::msg::DetectedObject & object, const double buffer);
@@ -50,11 +62,21 @@ Polygon2d to_polygon2d(
   const autoware_perception_msgs::msg::TrackedObject & object, const double buffer);
 Polygon2d to_polygon2d(
   const autoware_perception_msgs::msg::PredictedObject & object, const double buffer);
+
+Polygon2d to_polygon2d_safe(
+  const autoware_perception_msgs::msg::DetectedObject & object, const double buffer);
+Polygon2d to_polygon2d_safe(
+  const autoware_perception_msgs::msg::TrackedObject & object, const double buffer);
+Polygon2d to_polygon2d_safe(
+  const autoware_perception_msgs::msg::PredictedObject & object, const double buffer);
+
 Polygon2d to_footprint(
   const geometry_msgs::msg::Pose & base_link_pose, const double base_to_front,
   const double base_to_rear, const double width);
 double get_area(const autoware_perception_msgs::msg::Shape & shape);
+
 Polygon2d expand_polygon(const Polygon2d & input_polygon, const double offset);
+Polygon2d expand_polygon_safe(const Polygon2d & input_polygon, const double offset);
 }  // namespace autoware_utils_geometry
 
 #endif  // AUTOWARE_UTILS_GEOMETRY__BOOST_POLYGON_UTILS_HPP_

--- a/autoware_utils_geometry/src/geometry/boost_polygon_utils.cpp
+++ b/autoware_utils_geometry/src/geometry/boost_polygon_utils.cpp
@@ -174,20 +174,28 @@ Polygon2d to_polygon2d(
   // Guard against degenerate footprints that cannot form a valid area.
   constexpr double dummy_offset = 0.05;
   auto & outer = polygon.outer();
-  if (outer.size() == 1) {
+  auto add_2_dummy_points = [&]() {
     const auto p = outer.front();
     append_point_to_polygon(polygon, Point2d(p.x() + dummy_offset, p.y()));
     append_point_to_polygon(polygon, Point2d(p.x(), p.y() - dummy_offset));
+  };
+  if (outer.size() == 1) {
+    add_2_dummy_points();
   } else if (outer.size() == 2) {
     const auto & p0 = outer.at(0);
     const auto & p1 = outer.at(1);
     const double dx = p1.x() - p0.x();
     const double dy = p1.y() - p0.y();
-    const double len = std::hypot(dx, dy);
-    const double mx = 0.5 * (p0.x() + p1.x());
-    const double my = 0.5 * (p0.y() + p1.y());
-    append_point_to_polygon(
-      polygon, Point2d(mx + dy / len * dummy_offset, my - dx / len * dummy_offset));
+    const double len = std::sqrt(dx * dx + dy * dy);
+    if (len < dummy_offset) {
+      outer.pop_back();
+      add_2_dummy_points();
+    } else {
+      const double mx = 0.5 * (p0.x() + p1.x());
+      const double my = 0.5 * (p0.y() + p1.y());
+      const double inv_length = dummy_offset / len;
+      append_point_to_polygon(polygon, Point2d(mx + dy * inv_length, my - dx * inv_length));
+    }
   }
 
   // NOTE: push back the first point in order to close polygon

--- a/autoware_utils_geometry/src/geometry/boost_polygon_utils.cpp
+++ b/autoware_utils_geometry/src/geometry/boost_polygon_utils.cpp
@@ -171,12 +171,39 @@ Polygon2d to_polygon2d(
     throw std::logic_error("The shape type is not supported in autoware_utils.");
   }
 
+  // Guard against degenerate footprints that cannot form a valid area.
+  constexpr double dummy_offset = 0.05;
+  auto & outer = polygon.outer();
+  if (outer.size() == 1) {
+    const auto p = outer.front();
+    append_point_to_polygon(polygon, Point2d(p.x() + dummy_offset, p.y()));
+    append_point_to_polygon(polygon, Point2d(p.x(), p.y() - dummy_offset));
+  } else if (outer.size() == 2) {
+    const auto & p0 = outer.at(0);
+    const auto & p1 = outer.at(1);
+    const double dx = p1.x() - p0.x();
+    const double dy = p1.y() - p0.y();
+    const double len = std::hypot(dx, dy);
+    const double mx = 0.5 * (p0.x() + p1.x());
+    const double my = 0.5 * (p0.y() + p1.y());
+    append_point_to_polygon(
+      polygon, Point2d(mx + dy / len * dummy_offset, my - dx / len * dummy_offset));
+  }
+
   // NOTE: push back the first point in order to close polygon
   if (!polygon.outer().empty()) {
     append_point_to_polygon(polygon, polygon.outer().front());
   }
 
   return is_clockwise(polygon) ? polygon : inverse_clockwise(polygon);
+}
+
+autoware_utils_geometry::Polygon2d to_polygon2d(
+  const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape,
+  const double buffer)
+{
+  auto polygon = to_polygon2d(pose, shape);
+  return expand_polygon(polygon, buffer);
 }
 
 autoware_utils_geometry::Polygon2d to_polygon2d(
@@ -187,6 +214,13 @@ autoware_utils_geometry::Polygon2d to_polygon2d(
 }
 
 autoware_utils_geometry::Polygon2d to_polygon2d(
+  const autoware_perception_msgs::msg::DetectedObject & object, const double buffer)
+{
+  return autoware_utils_geometry::to_polygon2d(
+    object.kinematics.pose_with_covariance.pose, object.shape, buffer);
+}
+
+autoware_utils_geometry::Polygon2d to_polygon2d(
   const autoware_perception_msgs::msg::TrackedObject & object)
 {
   return autoware_utils_geometry::to_polygon2d(
@@ -194,10 +228,24 @@ autoware_utils_geometry::Polygon2d to_polygon2d(
 }
 
 autoware_utils_geometry::Polygon2d to_polygon2d(
+  const autoware_perception_msgs::msg::TrackedObject & object, const double buffer)
+{
+  return autoware_utils_geometry::to_polygon2d(
+    object.kinematics.pose_with_covariance.pose, object.shape, buffer);
+}
+
+autoware_utils_geometry::Polygon2d to_polygon2d(
   const autoware_perception_msgs::msg::PredictedObject & object)
 {
   return autoware_utils_geometry::to_polygon2d(
     object.kinematics.initial_pose_with_covariance.pose, object.shape);
+}
+
+autoware_utils_geometry::Polygon2d to_polygon2d(
+  const autoware_perception_msgs::msg::PredictedObject & object, const double buffer)
+{
+  return autoware_utils_geometry::to_polygon2d(
+    object.kinematics.initial_pose_with_covariance.pose, object.shape, buffer);
 }
 
 Polygon2d to_footprint(
@@ -238,22 +286,66 @@ double get_area(const autoware_perception_msgs::msg::Shape & shape)
 //       This function fixes the issue.
 Polygon2d expand_polygon(const Polygon2d & input_polygon, const double offset)
 {
-  // NOTE: input_polygon is supposed to have a duplicated point.
-  const size_t num_points = input_polygon.outer().size() - 1;
+  static constexpr double eps = 1e-2;
 
-  Polygon2d expanded_polygon;
-  for (size_t i = 0; i < num_points; ++i) {
-    const auto & curr_p = input_polygon.outer().at(i);
-    const auto & next_p = input_polygon.outer().at(i + 1);
-    const auto & prev_p =
-      i == 0 ? input_polygon.outer().at(num_points - 1) : input_polygon.outer().at(i - 1);
+  if (input_polygon.outer().size() < 3 || offset < eps) return input_polygon;
+
+  auto filtered_polygon = input_polygon.outer();
+  filtered_polygon.pop_back();
+
+  // NOTE: Remove invalid points from the polygon.
+  auto it = filtered_polygon.begin();
+  while (it != filtered_polygon.end()) {
+    const auto & curr_p = *it;
+    const auto & next_p =
+      it == std::prev(filtered_polygon.end()) ? filtered_polygon.front() : *(it + 1);
+    const auto & prev_p = it == filtered_polygon.begin() ? filtered_polygon.back() : *(it - 1);
 
     Eigen::Vector2d current_to_next(next_p.x() - curr_p.x(), next_p.y() - curr_p.y());
     Eigen::Vector2d current_to_prev(prev_p.x() - curr_p.x(), prev_p.y() - curr_p.y());
+
+    if (current_to_next.norm() < eps || current_to_prev.norm() < eps) {
+      it = filtered_polygon.erase(it);
+      continue;
+    }
+
+    current_to_next.normalize();
+    current_to_prev.normalize();
+    if (std::abs(current_to_next.dot(current_to_prev)) > (1.0 - eps)) {
+      it = filtered_polygon.erase(it);
+      continue;
+    }
+    it++;
+  }
+
+  if (filtered_polygon.size() < 3) return input_polygon;
+
+  filtered_polygon.push_back(filtered_polygon.front());
+  const size_t num_points = filtered_polygon.size() - 1;
+
+  Polygon2d expanded_polygon;
+  for (size_t i = 0; i < num_points; ++i) {
+    const auto & curr_p = filtered_polygon.at(i);
+    const auto & next_p = filtered_polygon.at(i + 1);
+    const auto & prev_p = i == 0 ? filtered_polygon.at(num_points - 1) : filtered_polygon.at(i - 1);
+
+    Eigen::Vector2d current_to_next(next_p.x() - curr_p.x(), next_p.y() - curr_p.y());
+    Eigen::Vector2d current_to_prev(prev_p.x() - curr_p.x(), prev_p.y() - curr_p.y());
+
+    // NOTE: If the current point is too close to the previous or next point, the polygon will be
+    // degenerate.
+    if (current_to_prev.norm() < eps || current_to_next.norm() < eps) {
+      return input_polygon;
+    }
     current_to_next.normalize();
     current_to_prev.normalize();
 
-    const Eigen::Vector2d offset_vector = (-current_to_next - current_to_prev).normalized();
+    Eigen::Vector2d offset_vector = (-current_to_next - current_to_prev);
+    // NOTE: If the offset vector is too small, the polygon will be degenerate.
+    if (offset_vector.norm() < eps) {
+      return input_polygon;
+    }
+    offset_vector.normalize();
     const double theta = std::acos(offset_vector.dot(current_to_next));
     const double scaled_offset = offset / std::sin(theta);
     const Eigen::Vector2d offset_point =

--- a/autoware_utils_geometry/src/geometry/boost_polygon_utils.cpp
+++ b/autoware_utils_geometry/src/geometry/boost_polygon_utils.cpp
@@ -117,61 +117,67 @@ Polygon2d rotate_polygon(const Polygon2d & polygon, const double angle)
   return rotated_polygon;
 }
 
-Polygon2d to_polygon2d(
-  const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape)
+Polygon2d bbox_to_polygon2d(
+  const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Vector3 & dimensions)
 {
   Polygon2d polygon;
+  const auto point0 =
+    autoware_utils_geometry::calc_offset_pose(pose, dimensions.x / 2.0, dimensions.y / 2.0, 0.0)
+      .position;
+  const auto point1 =
+    autoware_utils_geometry::calc_offset_pose(pose, -dimensions.x / 2.0, dimensions.y / 2.0, 0.0)
+      .position;
+  const auto point2 =
+    autoware_utils_geometry::calc_offset_pose(pose, -dimensions.x / 2.0, -dimensions.y / 2.0, 0.0)
+      .position;
+  const auto point3 =
+    autoware_utils_geometry::calc_offset_pose(pose, dimensions.x / 2.0, -dimensions.y / 2.0, 0.0)
+      .position;
+  append_point_to_polygon(polygon, point0);
+  append_point_to_polygon(polygon, point1);
+  append_point_to_polygon(polygon, point2);
+  append_point_to_polygon(polygon, point3);
+  return polygon;
+}
 
-  if (shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
-    const auto point0 = autoware_utils_geometry::calc_offset_pose(
-                          pose, shape.dimensions.x / 2.0, shape.dimensions.y / 2.0, 0.0)
-                          .position;
-    const auto point1 = autoware_utils_geometry::calc_offset_pose(
-                          pose, -shape.dimensions.x / 2.0, shape.dimensions.y / 2.0, 0.0)
-                          .position;
-    const auto point2 = autoware_utils_geometry::calc_offset_pose(
-                          pose, -shape.dimensions.x / 2.0, -shape.dimensions.y / 2.0, 0.0)
-                          .position;
-    const auto point3 = autoware_utils_geometry::calc_offset_pose(
-                          pose, shape.dimensions.x / 2.0, -shape.dimensions.y / 2.0, 0.0)
-                          .position;
-
-    append_point_to_polygon(polygon, point0);
-    append_point_to_polygon(polygon, point1);
-    append_point_to_polygon(polygon, point2);
-    append_point_to_polygon(polygon, point3);
-  } else if (shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
-    const double radius = shape.dimensions.x / 2.0;
-    constexpr int circle_discrete_num = 6;
-    for (int i = 0; i < circle_discrete_num; ++i) {
-      geometry_msgs::msg::Point point;
-      point.x = std::cos(
-                  (static_cast<double>(i) / static_cast<double>(circle_discrete_num)) * 2.0 * M_PI +
-                  M_PI / static_cast<double>(circle_discrete_num)) *
-                  radius +
-                pose.position.x;
-      point.y = std::sin(
-                  (static_cast<double>(i) / static_cast<double>(circle_discrete_num)) * 2.0 * M_PI +
-                  M_PI / static_cast<double>(circle_discrete_num)) *
-                  radius +
-                pose.position.y;
-      append_point_to_polygon(polygon, point);
-    }
-  } else if (shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
-    const double poly_yaw = tf2::getYaw(pose.orientation);
-    const auto rotated_footprint = rotate_polygon(shape.footprint, poly_yaw);
-    for (const auto rel_point : rotated_footprint.points) {
-      geometry_msgs::msg::Point abs_point;
-      abs_point.x = pose.position.x + rel_point.x;
-      abs_point.y = pose.position.y + rel_point.y;
-
-      append_point_to_polygon(polygon, abs_point);
-    }
-  } else {
-    throw std::logic_error("The shape type is not supported in autoware_utils.");
+Polygon2d cylinder_to_polygon2d(const geometry_msgs::msg::Pose & pose, const double radius)
+{
+  Polygon2d polygon;
+  constexpr int circle_discrete_num = 6;
+  for (int i = 0; i < circle_discrete_num; ++i) {
+    geometry_msgs::msg::Point point;
+    point.x = std::cos(
+                (static_cast<double>(i) / static_cast<double>(circle_discrete_num)) * 2.0 * M_PI +
+                M_PI / static_cast<double>(circle_discrete_num)) *
+                radius +
+              pose.position.x;
+    point.y = std::sin(
+                (static_cast<double>(i) / static_cast<double>(circle_discrete_num)) * 2.0 * M_PI +
+                M_PI / static_cast<double>(circle_discrete_num)) *
+                radius +
+              pose.position.y;
+    append_point_to_polygon(polygon, point);
   }
+  return polygon;
+}
 
-  // Guard against degenerate footprints that cannot form a valid area.
+Polygon2d footprint_to_polygon2d(
+  const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Polygon & footprint)
+{
+  Polygon2d polygon;
+  const double poly_yaw = tf2::getYaw(pose.orientation);
+  const auto rotated_footprint = rotate_polygon(footprint, poly_yaw);
+  for (const auto rel_point : rotated_footprint.points) {
+    geometry_msgs::msg::Point abs_point;
+    abs_point.x = pose.position.x + rel_point.x;
+    abs_point.y = pose.position.y + rel_point.y;
+    append_point_to_polygon(polygon, abs_point);
+  }
+  return polygon;
+}
+
+void fix_if_invalid(Polygon2d & polygon)
+{
   constexpr double dummy_offset = 0.05;
   auto & outer = polygon.outer();
   auto add_2_dummy_points = [&]() {
@@ -197,6 +203,48 @@ Polygon2d to_polygon2d(
       append_point_to_polygon(polygon, Point2d(mx + dy * inv_length, my - dx * inv_length));
     }
   }
+}
+
+Polygon2d to_polygon2d(
+  const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape)
+{
+  Polygon2d polygon;
+
+  if (shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    polygon = bbox_to_polygon2d(pose, shape.dimensions);
+  } else if (shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
+    polygon = cylinder_to_polygon2d(pose, shape.dimensions.x / 2.0);
+  } else if (shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
+    polygon = footprint_to_polygon2d(pose, shape.footprint);
+  } else {
+    throw std::logic_error("The shape type is not supported in autoware_utils.");
+  }
+
+  // NOTE: push back the first point in order to close polygon
+  if (!polygon.outer().empty()) {
+    append_point_to_polygon(polygon, polygon.outer().front());
+  }
+
+  return is_clockwise(polygon) ? polygon : inverse_clockwise(polygon);
+}
+
+Polygon2d to_polygon2d_safe(
+  const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape)
+{
+  Polygon2d polygon;
+
+  if (shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    polygon = bbox_to_polygon2d(pose, shape.dimensions);
+  } else if (shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
+    polygon = cylinder_to_polygon2d(pose, shape.dimensions.x / 2.0);
+  } else if (shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
+    polygon = footprint_to_polygon2d(pose, shape.footprint);
+  } else {
+    throw std::logic_error("The shape type is not supported in autoware_utils.");
+  }
+
+  // Guard against degenerate footprints that cannot form a valid area.
+  fix_if_invalid(polygon);
 
   // NOTE: push back the first point in order to close polygon
   if (!polygon.outer().empty()) {
@@ -256,6 +304,56 @@ autoware_utils_geometry::Polygon2d to_polygon2d(
     object.kinematics.initial_pose_with_covariance.pose, object.shape, buffer);
 }
 
+autoware_utils_geometry::Polygon2d to_polygon2d_safe(
+  const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape,
+  const double buffer)
+{
+  auto polygon = to_polygon2d_safe(pose, shape);
+  return expand_polygon_safe(polygon, buffer);
+}
+
+autoware_utils_geometry::Polygon2d to_polygon2d_safe(
+  const autoware_perception_msgs::msg::DetectedObject & object)
+{
+  return autoware_utils_geometry::to_polygon2d_safe(
+    object.kinematics.pose_with_covariance.pose, object.shape);
+}
+
+autoware_utils_geometry::Polygon2d to_polygon2d_safe(
+  const autoware_perception_msgs::msg::DetectedObject & object, const double buffer)
+{
+  return autoware_utils_geometry::to_polygon2d_safe(
+    object.kinematics.pose_with_covariance.pose, object.shape, buffer);
+}
+
+autoware_utils_geometry::Polygon2d to_polygon2d_safe(
+  const autoware_perception_msgs::msg::TrackedObject & object)
+{
+  return autoware_utils_geometry::to_polygon2d_safe(
+    object.kinematics.pose_with_covariance.pose, object.shape);
+}
+
+autoware_utils_geometry::Polygon2d to_polygon2d_safe(
+  const autoware_perception_msgs::msg::TrackedObject & object, const double buffer)
+{
+  return autoware_utils_geometry::to_polygon2d_safe(
+    object.kinematics.pose_with_covariance.pose, object.shape, buffer);
+}
+
+autoware_utils_geometry::Polygon2d to_polygon2d_safe(
+  const autoware_perception_msgs::msg::PredictedObject & object)
+{
+  return autoware_utils_geometry::to_polygon2d_safe(
+    object.kinematics.initial_pose_with_covariance.pose, object.shape);
+}
+
+autoware_utils_geometry::Polygon2d to_polygon2d_safe(
+  const autoware_perception_msgs::msg::PredictedObject & object, const double buffer)
+{
+  return autoware_utils_geometry::to_polygon2d_safe(
+    object.kinematics.initial_pose_with_covariance.pose, object.shape, buffer);
+}
+
 Polygon2d to_footprint(
   const geometry_msgs::msg::Pose & base_link_pose, const double base_to_front,
   const double base_to_rear, const double width)
@@ -293,6 +391,36 @@ double get_area(const autoware_perception_msgs::msg::Shape & shape)
 //       is larger than the original one.
 //       This function fixes the issue.
 Polygon2d expand_polygon(const Polygon2d & input_polygon, const double offset)
+{
+  // NOTE: input_polygon is supposed to have a duplicated point.
+  const size_t num_points = input_polygon.outer().size() - 1;
+
+  Polygon2d expanded_polygon;
+  for (size_t i = 0; i < num_points; ++i) {
+    const auto & curr_p = input_polygon.outer().at(i);
+    const auto & next_p = input_polygon.outer().at(i + 1);
+    const auto & prev_p =
+      i == 0 ? input_polygon.outer().at(num_points - 1) : input_polygon.outer().at(i - 1);
+
+    Eigen::Vector2d current_to_next(next_p.x() - curr_p.x(), next_p.y() - curr_p.y());
+    Eigen::Vector2d current_to_prev(prev_p.x() - curr_p.x(), prev_p.y() - curr_p.y());
+    current_to_next.normalize();
+    current_to_prev.normalize();
+
+    const Eigen::Vector2d offset_vector = (-current_to_next - current_to_prev).normalized();
+    const double theta = std::acos(offset_vector.dot(current_to_next));
+    const double scaled_offset = offset / std::sin(theta);
+    const Eigen::Vector2d offset_point =
+      Eigen::Vector2d(curr_p.x(), curr_p.y()) + offset_vector * scaled_offset;
+
+    expanded_polygon.outer().push_back(Point2d(offset_point.x(), offset_point.y()));
+  }
+
+  boost::geometry::correct(expanded_polygon);
+  return expanded_polygon;
+}
+
+Polygon2d expand_polygon_safe(const Polygon2d & input_polygon, const double offset)
 {
   static constexpr double eps = 1e-2;
 

--- a/autoware_utils_geometry/test/cases/boost_polygon_utils.cpp
+++ b/autoware_utils_geometry/test/cases/boost_polygon_utils.cpp
@@ -220,6 +220,11 @@ TEST(boost_geometry, boost_to_polygon2d)
     EXPECT_DOUBLE_EQ(poly.outer().at(4).x(), 1.0);
     EXPECT_DOUBLE_EQ(poly.outer().at(4).y(), 0.29289323091506958);
   }
+}
+
+TEST(boost_geometry, boost_to_polygon2d_safe)
+{
+  using autoware_utils_geometry::to_polygon2d_safe;
 
   {  // degenerate polygon with a single footprint point
     constexpr double dummy_offset = 0.05;
@@ -228,7 +233,7 @@ TEST(boost_geometry, boost_to_polygon2d)
     shape.type = autoware_perception_msgs::msg::Shape::POLYGON;
     shape.footprint.points.push_back(create_point32(0.0, 0.0));
 
-    const auto poly = to_polygon2d(pose, shape);
+    const auto poly = to_polygon2d_safe(pose, shape);
     ASSERT_EQ(poly.outer().size(), 4U);
     EXPECT_NEAR(poly.outer().at(0).x(), 2.0, 1e-6);
     EXPECT_NEAR(poly.outer().at(0).y(), 3.0, 1e-6);
@@ -250,7 +255,7 @@ TEST(boost_geometry, boost_to_polygon2d)
     shape.footprint.points.push_back(create_point32(0.0, 0.0));
     shape.footprint.points.push_back(create_point32(1.0, 0.0));
 
-    const auto poly = to_polygon2d(pose, shape);
+    const auto poly = to_polygon2d_safe(pose, shape);
     ASSERT_EQ(poly.outer().size(), 4U);
     EXPECT_NEAR(poly.outer().at(0).x(), 2.0, 1e-6);
     EXPECT_NEAR(poly.outer().at(0).y(), 3.0, 1e-6);
@@ -370,20 +375,45 @@ TEST(boost_geometry, boost_expand_polygon)
 
   {  // empty polygon
     Polygon2d empty_poly;
-    const auto expanded_poly = expand_polygon(empty_poly, 1.0);
+    EXPECT_THROW(expand_polygon(empty_poly, 1.0), std::out_of_range);
+  }
+}
+
+TEST(boost_geometry, boost_expand_polygon_safe)
+{
+  using autoware_utils_geometry::expand_polygon_safe;
+
+  {  // box with a certain offset
+    Polygon2d box_poly{{{-1.0, -1.0}, {-1.0, 1.0}, {1.0, 1.0}, {1.0, -1.0}, {-1.0, -1.0}}};
+    const auto expanded_poly = expand_polygon_safe(box_poly, 1.0);
+    const auto expected_poly =
+      Polygon2d{{{-2.0, -2.0}, {-2.0, 2.0}, {2.0, 2.0}, {2.0, -2.0}, {-2.0, -2.0}}};
+    EXPECT_TRUE(polygons_equal(expanded_poly, expected_poly));
+  }
+
+  {  // box with no offset
+    Polygon2d box_poly{{{-1.0, -1.0}, {-1.0, 1.0}, {1.0, 1.0}, {1.0, -1.0}, {-1.0, -1.0}}};
+    const auto expanded_poly = expand_polygon_safe(box_poly, 0.0);
+
+    EXPECT_TRUE(polygons_equal(expanded_poly, box_poly));
+  }
+
+  {  // empty polygon
+    Polygon2d empty_poly;
+    const auto expanded_poly = expand_polygon_safe(empty_poly, 1.0);
     EXPECT_EQ(expanded_poly.outer().size(), 0U);
   }
 
   {  // polygon with fewer than three unique points
     Polygon2d two_point_poly{{{0.0, 0.0}, {1.0, 0.0}}};
-    const auto expanded_poly = expand_polygon(two_point_poly, 1.0);
+    const auto expanded_poly = expand_polygon_safe(two_point_poly, 1.0);
     EXPECT_TRUE(polygons_equal(expanded_poly, two_point_poly));
   }
 
   {  // polygon with duplicate consecutive points
     Polygon2d duplicated_poly{
       {{-1.0, -1.0}, {-1.0, 1.0}, {-1.0, 1.0}, {1.0, 1.0}, {1.0, -1.0}, {-1.0, -1.0}}};
-    const auto expanded_poly = expand_polygon(duplicated_poly, 1.0);
+    const auto expanded_poly = expand_polygon_safe(duplicated_poly, 1.0);
     const auto expected_poly =
       Polygon2d{{{-2.0, -2.0}, {-2.0, 2.0}, {2.0, 2.0}, {2.0, -2.0}, {-2.0, -2.0}}};
     EXPECT_TRUE(polygons_equal(expanded_poly, expected_poly));
@@ -392,7 +422,7 @@ TEST(boost_geometry, boost_expand_polygon)
   {  // polygon with collinear points
     Polygon2d collinear_poly{
       {{-1.0, -1.0}, {-1.0, 1.0}, {0.0, 1.0}, {1.0, 1.0}, {1.0, -1.0}, {-1.0, -1.0}}};
-    const auto expanded_poly = expand_polygon(collinear_poly, 1.0);
+    const auto expanded_poly = expand_polygon_safe(collinear_poly, 1.0);
     const auto expected_poly =
       Polygon2d{{{-2.0, -2.0}, {-2.0, 2.0}, {2.0, 2.0}, {2.0, -2.0}, {-2.0, -2.0}}};
     EXPECT_TRUE(polygons_equal(expanded_poly, expected_poly));
@@ -400,7 +430,7 @@ TEST(boost_geometry, boost_expand_polygon)
 
   {  // polygon that becomes degenerate after filtering
     Polygon2d degenerate_poly{{{0.0, 0.0}, {1.0, 0.0}, {2.0, 0.0}, {0.0, 0.0}}};
-    const auto expanded_poly = expand_polygon(degenerate_poly, 1.0);
+    const auto expanded_poly = expand_polygon_safe(degenerate_poly, 1.0);
     EXPECT_TRUE(polygons_equal(expanded_poly, degenerate_poly));
   }
 }

--- a/autoware_utils_geometry/test/cases/boost_polygon_utils.cpp
+++ b/autoware_utils_geometry/test/cases/boost_polygon_utils.cpp
@@ -44,6 +44,22 @@ geometry_msgs::msg::Pose create_pose(const double x, const double y, const doubl
 
   return p;
 }
+
+bool polygons_equal(const Polygon2d & lhs, const Polygon2d & rhs, const double epsilon = 1e-6)
+{
+  if (lhs.outer().size() != rhs.outer().size()) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs.outer().size(); ++i) {
+    if (std::abs(lhs.outer().at(i).x() - rhs.outer().at(i).x()) > epsilon) {
+      return false;
+    }
+    if (std::abs(lhs.outer().at(i).y() - rhs.outer().at(i).y()) > epsilon) {
+      return false;
+    }
+  }
+  return true;
+}
 }  // namespace
 
 TEST(boost_geometry, boost_is_clockwise)
@@ -204,6 +220,49 @@ TEST(boost_geometry, boost_to_polygon2d)
     EXPECT_DOUBLE_EQ(poly.outer().at(4).x(), 1.0);
     EXPECT_DOUBLE_EQ(poly.outer().at(4).y(), 0.29289323091506958);
   }
+
+  {  // degenerate polygon with a single footprint point
+    constexpr double dummy_offset = 0.05;
+    const auto pose = create_pose(2.0, 3.0, 0.0);
+    autoware_perception_msgs::msg::Shape shape;
+    shape.type = autoware_perception_msgs::msg::Shape::POLYGON;
+    shape.footprint.points.push_back(create_point32(0.0, 0.0));
+
+    const auto poly = to_polygon2d(pose, shape);
+    ASSERT_EQ(poly.outer().size(), 4U);
+    EXPECT_NEAR(poly.outer().at(0).x(), 2.0, 1e-6);
+    EXPECT_NEAR(poly.outer().at(0).y(), 3.0, 1e-6);
+    EXPECT_NEAR(poly.outer().at(1).x(), 2.0 + dummy_offset, 1e-6);
+    EXPECT_NEAR(poly.outer().at(1).y(), 3.0, 1e-6);
+    EXPECT_NEAR(poly.outer().at(2).x(), 2.0, 1e-6);
+    EXPECT_NEAR(poly.outer().at(2).y(), 3.0 - dummy_offset, 1e-6);
+    EXPECT_NEAR(poly.outer().at(3).x(), poly.outer().at(0).x(), 1e-6);
+    EXPECT_NEAR(poly.outer().at(3).y(), poly.outer().at(0).y(), 1e-6);
+    EXPECT_GT(boost::geometry::area(poly), 0.0);
+    EXPECT_TRUE(autoware_utils_geometry::is_clockwise(poly));
+  }
+
+  {  // degenerate polygon with two footprint points
+    constexpr double dummy_offset = 0.05;
+    const auto pose = create_pose(2.0, 3.0, 0.0);
+    autoware_perception_msgs::msg::Shape shape;
+    shape.type = autoware_perception_msgs::msg::Shape::POLYGON;
+    shape.footprint.points.push_back(create_point32(0.0, 0.0));
+    shape.footprint.points.push_back(create_point32(1.0, 0.0));
+
+    const auto poly = to_polygon2d(pose, shape);
+    ASSERT_EQ(poly.outer().size(), 4U);
+    EXPECT_NEAR(poly.outer().at(0).x(), 2.0, 1e-6);
+    EXPECT_NEAR(poly.outer().at(0).y(), 3.0, 1e-6);
+    EXPECT_NEAR(poly.outer().at(1).x(), 3.0, 1e-6);
+    EXPECT_NEAR(poly.outer().at(1).y(), 3.0, 1e-6);
+    EXPECT_NEAR(poly.outer().at(2).x(), 2.5, 1e-6);
+    EXPECT_NEAR(poly.outer().at(2).y(), 3.0 - dummy_offset, 1e-6);
+    EXPECT_NEAR(poly.outer().at(3).x(), poly.outer().at(0).x(), 1e-6);
+    EXPECT_NEAR(poly.outer().at(3).y(), poly.outer().at(0).y(), 1e-6);
+    EXPECT_GT(boost::geometry::area(poly), 0.0);
+    EXPECT_TRUE(autoware_utils_geometry::is_clockwise(poly));
+  }
 }
 
 TEST(boost_geometry, boost_to_footprint)
@@ -297,37 +356,51 @@ TEST(boost_geometry, boost_expand_polygon)
   {  // box with a certain offset
     Polygon2d box_poly{{{-1.0, -1.0}, {-1.0, 1.0}, {1.0, 1.0}, {1.0, -1.0}, {-1.0, -1.0}}};
     const auto expanded_poly = expand_polygon(box_poly, 1.0);
-
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(0).x(), -2.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(0).y(), -2.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(1).x(), -2.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(1).y(), 2.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(2).x(), 2.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(2).y(), 2.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(3).x(), 2.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(3).y(), -2.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(4).x(), -2.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(4).y(), -2.0);
+    const auto expected_poly =
+      Polygon2d{{{-2.0, -2.0}, {-2.0, 2.0}, {2.0, 2.0}, {2.0, -2.0}, {-2.0, -2.0}}};
+    EXPECT_TRUE(polygons_equal(expanded_poly, expected_poly));
   }
 
   {  // box with no offset
     Polygon2d box_poly{{{-1.0, -1.0}, {-1.0, 1.0}, {1.0, 1.0}, {1.0, -1.0}, {-1.0, -1.0}}};
     const auto expanded_poly = expand_polygon(box_poly, 0.0);
 
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(0).x(), -1.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(0).y(), -1.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(1).x(), -1.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(1).y(), 1.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(2).x(), 1.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(2).y(), 1.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(3).x(), 1.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(3).y(), -1.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(4).x(), -1.0);
-    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(4).y(), -1.0);
+    EXPECT_TRUE(polygons_equal(expanded_poly, box_poly));
   }
 
   {  // empty polygon
     Polygon2d empty_poly;
-    EXPECT_THROW(expand_polygon(empty_poly, 1.0), std::out_of_range);
+    const auto expanded_poly = expand_polygon(empty_poly, 1.0);
+    EXPECT_EQ(expanded_poly.outer().size(), 0U);
+  }
+
+  {  // polygon with fewer than three unique points
+    Polygon2d two_point_poly{{{0.0, 0.0}, {1.0, 0.0}}};
+    const auto expanded_poly = expand_polygon(two_point_poly, 1.0);
+    EXPECT_TRUE(polygons_equal(expanded_poly, two_point_poly));
+  }
+
+  {  // polygon with duplicate consecutive points
+    Polygon2d duplicated_poly{
+      {{-1.0, -1.0}, {-1.0, 1.0}, {-1.0, 1.0}, {1.0, 1.0}, {1.0, -1.0}, {-1.0, -1.0}}};
+    const auto expanded_poly = expand_polygon(duplicated_poly, 1.0);
+    const auto expected_poly =
+      Polygon2d{{{-2.0, -2.0}, {-2.0, 2.0}, {2.0, 2.0}, {2.0, -2.0}, {-2.0, -2.0}}};
+    EXPECT_TRUE(polygons_equal(expanded_poly, expected_poly));
+  }
+
+  {  // polygon with collinear points
+    Polygon2d collinear_poly{
+      {{-1.0, -1.0}, {-1.0, 1.0}, {0.0, 1.0}, {1.0, 1.0}, {1.0, -1.0}, {-1.0, -1.0}}};
+    const auto expanded_poly = expand_polygon(collinear_poly, 1.0);
+    const auto expected_poly =
+      Polygon2d{{{-2.0, -2.0}, {-2.0, 2.0}, {2.0, 2.0}, {2.0, -2.0}, {-2.0, -2.0}}};
+    EXPECT_TRUE(polygons_equal(expanded_poly, expected_poly));
+  }
+
+  {  // polygon that becomes degenerate after filtering
+    Polygon2d degenerate_poly{{{0.0, 0.0}, {1.0, 0.0}, {2.0, 0.0}, {0.0, 0.0}}};
+    const auto expanded_poly = expand_polygon(degenerate_poly, 1.0);
+    EXPECT_TRUE(polygons_equal(expanded_poly, degenerate_poly));
   }
 }


### PR DESCRIPTION
## Description

This PR adds safer polygon conversion/expansion APIs for degenerate perception footprints, while keeping the existing `to_polygon2d()` and `expand_polygon()` behavior unchanged. It also adds buffered `to_polygon2d` overloads for convenience.


### Background
Perception objects can occasionally carry invalid or degenerate `POLYGON` footprints (single point, line segment, duplicate/collinear vertices). Passing these directly into Boost.Geometry operations can produce invalid polygons, unstable expansion, or runtime failures. An example is shown below:

<img width="1920" height="1080" alt="Screenshot from 2026-08-04 10-14-45" src="https://github.com/user-attachments/assets/5ca87877-a9a0-4348-9227-1613611a595d" />

This PR introduces `*_safe` variants that callers can opt into when robustness against degenerate inputs is required.

### Changes
- Add `to_polygon2d_safe()`:
  - 1-point footprint → adds two offset vertices (0.05 m) to form a small triangle
  - 2-point footprint → adds a perpendicular offset vertex at the segment midpoint to form a triangle
  - Includes overloads for buffered polygons and perception object types
- Add `expand_polygon_safe()`:
  - Early return for inputs with fewer than 3 vertices or negligible buffer (`offset < 1e-2`)
  - Pre-filters invalid vertices before expansion (duplicate consecutive points, collinear points)
  - Returns the original polygon unchanged if filtering leaves fewer than 3 vertices
  - Guards the expansion loop against remaining degeneracy (zero-length edges, zero offset vector)
- Add unit tests for the safe APIs (degenerate footprints, empty/short/collinear polygons)
- Add `to_polygon2d(..., buffer)` overloads to reduce boilerplate at call sites

## How was this PR tested?
- `colcon build --packages-select autoware_utils_geometry --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release`
- `colcon test --packages-select autoware_utils_geometry`

## Notes for reviewers

None.

## Effects on system behavior

None.
